### PR TITLE
config/ file and get_data/ script updates

### DIFF
--- a/config/Arachis2_4_1_0.conf
+++ b/config/Arachis2_4_1_0.conf
@@ -18,9 +18,9 @@ work_dir="$PWD/../work_Arachis2_4_1_0"
 # The nth listed GFF file corresponds to the nth listed FASTA file.
 
 annotation_files=(
-  data/arahy.BaileyII.gnm1.ann1.PQM7.cds.bed.gz
-  data/arahy.Tifrunner.gnm1.ann2.TN8K.cds.bed.gz
-  data/arahy.Tifrunner.gnm2.ann1.4K0L.cds.bed.gz
+  data/arahy.BaileyII.gnm1.ann1.PQM7.gene_models_main.bed.gz
+  data/arahy.Tifrunner.gnm1.ann2.TN8K.gene_models_main.bed.gz
+  data/arahy.Tifrunner.gnm2.ann1.4K0L.gene_models_main.bed.gz
   data/arahy.Tifrunner.gnm2.ann2.PVFB.gene_models_main.bed.gz
 )
 
@@ -33,7 +33,7 @@ cds_files=(
 
 ### (optional) Extra GFF & FASTA files
 annotation_files_extra_constr=(
-  data/araduip.V14167K30076.gnm1.ann1.cxSMJ37m.cds.bed.gz
+  data/araduip.V14167K30076.gnm1.ann1.cxSMJ37m.gene_models_main.bed.gz
 )
 
 cds_files_extra_constr=(

--- a/config/Arachis2_5_2_0.conf
+++ b/config/Arachis2_5_2_0.conf
@@ -18,10 +18,10 @@ work_dir="$PWD/../work_Arachis2_5_2_0"
 # The nth listed GFF file corresponds to the nth listed FASTA file.
 
 annotation_files=(
-  data/arahy.BaileyII.gnm1.ann1.PQM7.cds.bed.gz
-  data/arahy.Tifrunner.gnm1.ann1.CCJH.cds.bed.gz
-  data/arahy.Tifrunner.gnm1.ann2.TN8K.cds.bed.gz
-  data/arahy.Tifrunner.gnm2.ann1.4K0L.cds.bed.gz
+  data/arahy.BaileyII.gnm1.ann1.PQM7.gene_models_main.bed.gz
+  data/arahy.Tifrunner.gnm1.ann1.CCJH.gene_models_main.bed.gz
+  data/arahy.Tifrunner.gnm1.ann2.TN8K.gene_models_main.bed.gz
+  data/arahy.Tifrunner.gnm2.ann1.4K0L.gene_models_main.bed.gz
   data/arahy.Tifrunner.gnm2.ann2.PVFB.gene_models_main.bed.gz
 )
 
@@ -35,7 +35,7 @@ cds_files=(
 
 ### (optional) Extra GFF & FASTA files
 annotation_files_extra_constr=(
-  data/araduip.V14167K30076.gnm1.ann1.cxSMJ37m.cds.bed.gz
+  data/araduip.V14167K30076.gnm1.ann1.cxSMJ37m.gene_models_main.bed.gz
 )
 
 cds_files_extra_constr=(

--- a/config/Cicer2_4_2_0.conf
+++ b/config/Cicer2_4_2_0.conf
@@ -18,10 +18,10 @@ work_dir="$PWD/../work_Cicer2_4_2_0"
 # The nth listed GFF file corresponds to the nth listed FASTA file.
 
 annotation_files=(
-  data/cicar.CDCFrontier.gnm3.ann1.NPD7.cds.bed.gz
-  data/cicar.ICC4958.gnm2.ann1.LCVX.cds.bed.gz
-  data/cicec.S2Drd065.gnm1.ann1.YZ9H.cds.bed.gz
-  data/cicre.Besev079.gnm1.ann1.F01Z.cds.bed.gz
+  data/cicar.CDCFrontier.gnm3.ann1.NPD7.gene_models_main.bed.gz
+  data/cicar.ICC4958.gnm2.ann1.LCVX.gene_models_main.bed.gz
+  data/cicec.S2Drd065.gnm1.ann1.YZ9H.gene_models_main.bed.gz
+  data/cicre.Besev079.gnm1.ann1.F01Z.gene_models_main.bed.gz
 )
 
 cds_files=(
@@ -34,8 +34,8 @@ cds_files=(
 
 ### (optional) Extra GFF & FASTA files
 annotation_files_extra_constr=(
-  data/cicar.CDCFrontier.gnm1.ann1.nRhs.cds.bed.gz
-  data/cicar.CDCFrontier.gnm2.ann1.9M1L.cds.bed.gz
+  data/cicar.CDCFrontier.gnm1.ann1.nRhs.gene_models_main.bed.gz
+  data/cicar.CDCFrontier.gnm2.ann1.9M1L.gene_models_main.bed.gz
 )
 
 cds_files_extra_constr=(

--- a/config/Glycine5_18_31_6.conf
+++ b/config/Glycine5_18_31_6.conf
@@ -21,7 +21,7 @@ annotation_files=(
 data/glyma.FiskebyIII.gnm1.ann1.SS25.gene_models_main.bed.gz
 data/glyma.Hefeng25_IGA1002.gnm1.ann1.320V.gene_models_main.bed.gz
 data/glyma.Huaxia3_IGA1007.gnm1.ann1.LKC7.gene_models_main.bed.gz
-data/glyma.JD17.gnm1.ann1.CLFP.cds.bed.gz
+data/glyma.JD17.gnm1.ann1.CLFP.gene_models_main.bed.gz
 data/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.gene_models_main.bed.gz
 data/glyma.Lee.gnm1.ann1.6NZV.gene_models_main.bed.gz
 data/glyma.Lee.gnm2.ann1.1FNT.gene_models_main.bed.gz
@@ -72,7 +72,7 @@ data/glyma.JiDouNo_17.gnm1.ann1.X5PX.gene_models_main.bed.gz
 data/glyma.JinDouNo_23.gnm1.ann1.SGJW.gene_models_main.bed.gz
 data/glyma.JuXuanNo_23.gnm1.ann1.H8PW.gene_models_main.bed.gz
 data/glyma.KeShanNo_1.gnm1.ann1.2YX4.gene_models_main.bed.gz
-data/glyma.Lee.gnm3.ann1.ZYY3.cds.bed.gz
+data/glyma.Lee.gnm3.ann1.ZYY3.gene_models_main.bed.gz
 data/glyma.PI_398296.gnm1.ann1.B0XR.gene_models_main.bed.gz
 data/glyma.PI_548362.gnm1.ann1.LL84.gene_models_main.bed.gz
 data/glyma.QiHuangNo_34.gnm1.ann1.WHRV.gene_models_main.bed.gz
@@ -82,7 +82,7 @@ data/glyma.TieJiaSiLiHuang.gnm1.ann1.W70Z.gene_models_main.bed.gz
 data/glyma.TongShanTianEDan.gnm1.ann1.56XW.gene_models_main.bed.gz
 data/glyma.WanDouNo_28.gnm1.ann1.NLYP.gene_models_main.bed.gz
 data/glyma.Wm82.gnm1.ann1.DvBy.gene_models_main.bed.gz
-data/glyma.Wm82.gnm5.ann1.J7HW.cds.bed.gz
+data/glyma.Wm82.gnm5.ann1.J7HW.gene_models_main.bed.gz
 data/glyma.XuDouNo_1.gnm1.ann1.G2T7.gene_models_main.bed.gz
 data/glyma.YuDouNo_22.gnm1.ann1.HCQ1.gene_models_main.bed.gz
 data/glyma.Zh13.gnm2.ann1.FJ3G.gene_models_main.bed.gz

--- a/config/Medicago2_7_0_16.conf
+++ b/config/Medicago2_7_0_16.conf
@@ -18,13 +18,13 @@ work_dir="$PWD/../work_Medicago2_7_0_16"
 # The nth listed GFF file corresponds to the nth listed FASTA file.
 
 annotation_files=(
-  data/medtr.A17.gnm5.ann1_6.L2RX.cds.bed.gz
-  data/medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed.gz
-  data/medtr.R108.gnmHiC_1.ann1.Y8NH.cds.bed.gz
-  data/medsa.XinJiangDaYe_1.gnm1.ann1.RKB9.cds.bed.gz
-  data/medsa.XinJiangDaYe_2.gnm1.ann1.RKB9.cds.bed.gz
-  data/medsa.XinJiangDaYe_3.gnm1.ann1.RKB9.cds.bed.gz
-  data/medsa.XinJiangDaYe_4.gnm1.ann1.RKB9.cds.bed.gz
+  data/medtr.A17.gnm5.ann1_6.L2RX.gene_models_main.bed.gz
+  data/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed.gz
+  data/medtr.R108.gnmHiC_1.ann1.Y8NH.gene_models_main.bed.gz
+  data/medsa.XinJiangDaYe_1.gnm1.ann1.RKB9.gene_models_main.bed.gz
+  data/medsa.XinJiangDaYe_2.gnm1.ann1.RKB9.gene_models_main.bed.gz
+  data/medsa.XinJiangDaYe_3.gnm1.ann1.RKB9.gene_models_main.bed.gz
+  data/medsa.XinJiangDaYe_4.gnm1.ann1.RKB9.gene_models_main.bed.gz
 )
 
 cds_files=(
@@ -39,22 +39,22 @@ cds_files=(
 
 ### (optional) Extra GFF & FASTA files
 annotation_files_extra_free=(
-  data/medsa.XinJiangDaYe_sc.gnm1.ann1.RKB9.cds.bed.gz
-  data/medtr.R108_HM340.gnm1.ann1.85YW.cds.bed.gz
-  data/medtr.HM004.gnm1.ann1.2XTB.cds.bed.gz
-  data/medtr.HM010.gnm1.ann1.WV9J.cds.bed.gz
-  data/medtr.HM022.gnm1.ann1.6C8N.cds.bed.gz
-  data/medtr.HM023.gnm1.ann1.WZN8.cds.bed.gz
-  data/medtr.HM034.gnm1.ann1.YR6S.cds.bed.gz
-  data/medtr.HM050.gnm1.ann1.GWRX.cds.bed.gz
-  data/medtr.HM056.gnm1.ann1.CHP6.cds.bed.gz
-  data/medtr.HM058.gnm1.ann1.LXPZ.cds.bed.gz
-  data/medtr.HM060.gnm1.ann1.H41P.cds.bed.gz
-  data/medtr.HM095.gnm1.ann1.55W4.cds.bed.gz
-  data/medtr.HM125.gnm1.ann1.KY5W.cds.bed.gz
-  data/medtr.HM129.gnm1.ann1.7FTD.cds.bed.gz
-  data/medtr.HM185.gnm1.ann1.GB3D.cds.bed.gz
-  data/medtr.HM324.gnm1.ann1.SQH2.cds.bed.gz
+  data/medsa.XinJiangDaYe_sc.gnm1.ann1.RKB9.gene_models_main.bed.gz
+  data/medtr.R108_HM340.gnm1.ann1.85YW.gene_models_main.bed.gz
+  data/medtr.HM004.gnm1.ann1.2XTB.gene_models_main.bed.gz
+  data/medtr.HM010.gnm1.ann1.WV9J.gene_models_main.bed.gz
+  data/medtr.HM022.gnm1.ann1.6C8N.gene_models_main.bed.gz
+  data/medtr.HM023.gnm1.ann1.WZN8.gene_models_main.bed.gz
+  data/medtr.HM034.gnm1.ann1.YR6S.gene_models_main.bed.gz
+  data/medtr.HM050.gnm1.ann1.GWRX.gene_models_main.bed.gz
+  data/medtr.HM056.gnm1.ann1.CHP6.gene_models_main.bed.gz
+  data/medtr.HM058.gnm1.ann1.LXPZ.gene_models_main.bed.gz
+  data/medtr.HM060.gnm1.ann1.H41P.gene_models_main.bed.gz
+  data/medtr.HM095.gnm1.ann1.55W4.gene_models_main.bed.gz
+  data/medtr.HM125.gnm1.ann1.KY5W.gene_models_main.bed.gz
+  data/medtr.HM129.gnm1.ann1.7FTD.gene_models_main.bed.gz
+  data/medtr.HM185.gnm1.ann1.GB3D.gene_models_main.bed.gz
+  data/medtr.HM324.gnm1.ann1.SQH2.gene_models_main.bed.gz
 )
 
 cds_files_extra_free=(

--- a/config/Phaseolus2_7_1_0.conf
+++ b/config/Phaseolus2_7_1_0.conf
@@ -18,13 +18,13 @@ work_dir="$PWD/../work_Phaseolus2_7_1_0"
 # The nth listed GFF file corresponds to the nth listed FASTA file.
 
 annotation_files=(
-  data/phaac.Frijol_Bayo.gnm1.ann1.ML22.cds.bed.gz
-  data/phaac.W6_15578.gnm2.ann1.LVZ1.cds.bed.gz
-  data/phalu.G27455.gnm1.ann1.JD7C.cds.bed.gz
-  data/phavu.5-593.gnm1.ann1.3FBJ.cds.bed.gz
-  data/phavu.G19833.gnm2.ann1.PB8d.cds.bed.gz
-  data/phavu.LaborOvalle.gnm1.ann1.L1DY.cds.bed.gz
-  data/phavu.UI111.gnm1.ann1.8L4N.cds.bed.gz
+  data/phaac.Frijol_Bayo.gnm1.ann1.ML22.gene_models_main.bed.gz
+  data/phaac.W6_15578.gnm2.ann1.LVZ1.gene_models_main.bed.gz
+  data/phalu.G27455.gnm1.ann1.JD7C.gene_models_main.bed.gz
+  data/phavu.5-593.gnm1.ann1.3FBJ.gene_models_main.bed.gz
+  data/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.bed.gz
+  data/phavu.LaborOvalle.gnm1.ann1.L1DY.gene_models_main.bed.gz
+  data/phavu.UI111.gnm1.ann1.8L4N.gene_models_main.bed.gz
 )
 
 cds_files=(
@@ -39,7 +39,7 @@ cds_files=(
 
 ### (optional) Extra GFF & FASTA files
 annotation_files_extra_constr=(
-  data/phavu.G19833.gnm1.ann1.pScz.cds.bed.gz
+  data/phavu.G19833.gnm1.ann1.pScz.gene_models_main.bed.gz
 )
 
 cds_files_extra_constr=(

--- a/config/Vigna3_7_1_4.conf
+++ b/config/Vigna3_7_1_4.conf
@@ -18,13 +18,13 @@ work_dir="$PWD/../work_Vigna"
 # The nth listed GFF file corresponds to the nth listed FASTA file.
 
 annotation_files=(
-  data/vigun.CB5-2.gnm1.ann1.0GKC.cds.bed.gz
-  data/vigun.IT97K-499-35.gnm1.ann2.FD7K.cds.bed.gz
-  data/vigun.Sanzi.gnm1.ann1.HFH8.cds.bed.gz
-  data/vigun.Suvita2.gnm1.ann1.1PF6.cds.bed.gz
-  data/vigun.TZ30.gnm1.ann2.59NL.cds.bed.gz
-  data/vigun.UCR779.gnm1.ann1.VF6G.cds.bed.gz
-  data/vigun.ZN016.gnm1.ann2.C7YV.cds.bed.gz
+  data/vigun.CB5-2.gnm1.ann1.0GKC.gene_models_main.bed.gz
+  data/vigun.IT97K-499-35.gnm1.ann2.FD7K.gene_models_main.bed.gz
+  data/vigun.Sanzi.gnm1.ann1.HFH8.gene_models_main.bed.gz
+  data/vigun.Suvita2.gnm1.ann1.1PF6.gene_models_main.bed.gz
+  data/vigun.TZ30.gnm1.ann2.59NL.gene_models_main.bed.gz
+  data/vigun.UCR779.gnm1.ann1.VF6G.gene_models_main.bed.gz
+  data/vigun.ZN016.gnm1.ann2.C7YV.gene_models_main.bed.gz
 )
 
 cds_files=(
@@ -39,10 +39,10 @@ cds_files=(
 
 ### (optional) Extra GFF & FASTA files
 annotation_files_extra_constr=(
-  data/vigun.IT97K-499-35.gnm1.ann1.zb5D.cds.bed.gz
+  data/vigun.IT97K-499-35.gnm1.ann1.zb5D.gene_models_main.bed.gz
 )
 # vigun.Xiabao_II.gnm1 has a bad annotation, and chromosomes don't correspond with other vigun assemblies
-# data/vigun.Xiabao_II.gnm1.ann1.4JFL.cds.bed.gz   
+# data/vigun.Xiabao_II.gnm1.ann1.4JFL.gene_models_main.bed.gz   
 
 cds_files_extra_constr=(
   data/vigun.IT97K-499-35.gnm1.ann1.zb5D.cds_primary.fna.gz
@@ -51,10 +51,10 @@ cds_files_extra_constr=(
 
 ### (optional) Extra GFF & FASTA files
 annotation_files_extra_free=(
-  data/vigan.Gyeongwon.gnm3.ann1.3Nz5.cds.bed.gz
-  data/vigan.Shumari.gnm1.ann1.8BRS.cds.bed.gz
-  data/vigra.VC1973A.gnm6.ann1.M1Qs.cds.bed.gz
-  data/vigra.VC1973A.gnm7.ann1.RWBG.cds.bed.gz
+  data/vigan.Gyeongwon.gnm3.ann1.3Nz5.gene_models_main.bed.gz
+  data/vigan.Shumari.gnm1.ann1.8BRS.gene_models_main.bed.gz
+  data/vigra.VC1973A.gnm6.ann1.M1Qs.gene_models_main.bed.gz
+  data/vigra.VC1973A.gnm7.ann1.RWBG.gene_models_main.bed.gz
 )
 
 cds_files_extra_free=(

--- a/config/family3_18_3.conf
+++ b/config/family3_18_3.conf
@@ -13,92 +13,92 @@ consen_prefix='Legume.fam3.'
 annot_str_regex='([^.]+\.[^.]+)\..+'
 work_dir="$PWD/../work_family3_18_3"
 
-expected_quotas='FAM_data/expected_quotas.tsv'
+expected_quotas='data/expected_quotas.tsv'
 
-ks_cutoffs='FAM_data/ks_peaks.tsv'
+ks_cutoffs='data/ks_peaks.tsv'
 
 ##### (required) list of BED & FASTA file paths
 # Uncomment add file paths to the the annotation_files and cds_files arrays.
 # The nth listed BED file corresponds to the nth listed FASTA file.
 
 annotation_files=(
-  FAM_data/aesev.CIAT22838.gnm1.ann1.ZM3R.protein.bed.gz
-  FAM_data/Arachis.pan2.5P1K.pctl40_named_protein.bed.gz
-  FAM_data/cerca.ISC453364.gnm3.ann1.3N1M.protein.bed.gz
-  FAM_data/chafa.ISC494698.gnm1.ann1.G7XW.protein.bed.gz
-  FAM_data/Cicer.pan2.CMWZ.pctl25_named_protein.bed.gz
-  FAM_data/dalod.SKLTGB.gnm1.ann1.R67B.protein.bed.gz
-  FAM_data/Glycine.pan4.RK4P.pctl25_named_protein.bed.gz
-  FAM_data/lencu.CDC_Redberry.gnm2.ann1.5FB4.protein.bed.gz
-  FAM_data/lotja.MG20.gnm3.ann1.WF9B.protein.bed.gz
-  FAM_data/lupal.Amiga.gnm1.ann1.3GKS.protein.bed.gz
-  FAM_data/Medicago.pan2.451K.pctl25_named_protein.bed.gz
-  FAM_data/Phaseolus.pan2.G5HV.pctl25_named_protein.bed.gz
-  FAM_data/pissa.Cameor.gnm1.ann1.7SZR.protein.bed.gz
-  FAM_data/quisa.S10.gnm1.ann1.RQ4J.protein.bed.gz
-  FAM_data/sento.Myeongyun.gnm1.ann1.gene_models_main.bed.gz
-  FAM_data/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.bed.gz
-  FAM_data/vicfa.Hedin2.gnm1.ann1.PTNK.protein.bed.gz
-  FAM_data/Vigna.pan2.MQQM.pctl25_named_protein.bed.gz
+  data/aesev.CIAT22838.gnm1.ann1.ZM3R.protein.bed.gz
+  data/Arachis.pan2.5P1K.pctl40_named_protein.bed.gz
+  data/cerca.ISC453364.gnm3.ann1.3N1M.protein.bed.gz
+  data/chafa.ISC494698.gnm1.ann1.G7XW.protein.bed.gz
+  data/Cicer.pan2.CMWZ.pctl25_named_protein.bed.gz
+  data/dalod.SKLTGB.gnm1.ann1.R67B.protein.bed.gz
+  data/Glycine.pan4.RK4P.pctl25_named_protein.bed.gz
+  data/lencu.CDC_Redberry.gnm2.ann1.5FB4.protein.bed.gz
+  data/lotja.MG20.gnm3.ann1.WF9B.protein.bed.gz
+  data/lupal.Amiga.gnm1.ann1.3GKS.protein.bed.gz
+  data/Medicago.pan2.451K.pctl25_named_protein.bed.gz
+  data/Phaseolus.pan2.G5HV.pctl25_named_protein.bed.gz
+  data/pissa.Cameor.gnm1.ann1.7SZR.protein.bed.gz
+  data/quisa.S10.gnm1.ann1.RQ4J.protein.bed.gz
+  data/sento.Myeongyun.gnm1.ann1.gene_models_main.bed.gz
+  data/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.bed.gz
+  data/vicfa.Hedin2.gnm1.ann1.PTNK.protein.bed.gz
+  data/Vigna.pan2.MQQM.pctl25_named_protein.bed.gz
 )
 
 protein_files=(
-  FAM_data/aesev.CIAT22838.gnm1.ann1.ZM3R.protein_primary.faa.gz
-  FAM_data/Arachis.pan2.5P1K.pctl40_named_protein.faa.gz
-  FAM_data/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
-  FAM_data/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
-  FAM_data/Cicer.pan2.CMWZ.pctl25_named_protein.faa.gz
-  FAM_data/dalod.SKLTGB.gnm1.ann1.R67B.protein.faa.gz
-  FAM_data/Glycine.pan4.RK4P.pctl25_named_protein.faa.gz
-  FAM_data/lencu.CDC_Redberry.gnm2.ann1.5FB4.protein.faa.gz
-  FAM_data/lotja.MG20.gnm3.ann1.WF9B.protein_primary.faa.gz
-  FAM_data/lupal.Amiga.gnm1.ann1.3GKS.protein.faa.gz
-  FAM_data/Medicago.pan2.451K.pctl25_named_protein.faa.gz
-  FAM_data/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
-  FAM_data/pissa.Cameor.gnm1.ann1.7SZR.protein_primary.faa.gz
-  FAM_data/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
-  FAM_data/sento.Myeongyun.gnm1.ann1.protein.faa.gz
-  FAM_data/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
-  FAM_data/vicfa.Hedin2.gnm1.ann1.PTNK.protein_primary.faa.gz
-  FAM_data/Vigna.pan2.MQQM.pctl25_named_protein.faa.gz
+  data/aesev.CIAT22838.gnm1.ann1.ZM3R.protein_primary.faa.gz
+  data/Arachis.pan2.5P1K.pctl40_named_protein.faa.gz
+  data/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
+  data/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
+  data/Cicer.pan2.CMWZ.pctl25_named_protein.faa.gz
+  data/dalod.SKLTGB.gnm1.ann1.R67B.protein.faa.gz
+  data/Glycine.pan4.RK4P.pctl25_named_protein.faa.gz
+  data/lencu.CDC_Redberry.gnm2.ann1.5FB4.protein.faa.gz
+  data/lotja.MG20.gnm3.ann1.WF9B.protein_primary.faa.gz
+  data/lupal.Amiga.gnm1.ann1.3GKS.protein.faa.gz
+  data/Medicago.pan2.451K.pctl25_named_protein.faa.gz
+  data/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
+  data/pissa.Cameor.gnm1.ann1.7SZR.protein_primary.faa.gz
+  data/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
+  data/sento.Myeongyun.gnm1.ann1.protein.faa.gz
+  data/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
+  data/vicfa.Hedin2.gnm1.ann1.PTNK.protein_primary.faa.gz
+  data/Vigna.pan2.MQQM.pctl25_named_protein.faa.gz
 )
 
 cds_files=(
-  FAM_data/aesev.CIAT22838.gnm1.ann1.ZM3R.cds_primary.fna.gz
-  FAM_data/Arachis.pan2.5P1K.pctl40_named_cds.fna.gz
-  FAM_data/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
-  FAM_data/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
-  FAM_data/Cicer.pan2.CMWZ.pctl25_named_cds.fna.gz
-  FAM_data/dalod.SKLTGB.gnm1.ann1.R67B.cds.fna.gz
-  FAM_data/Glycine.pan4.RK4P.pctl25_named_cds.fna.gz
-  FAM_data/lencu.CDC_Redberry.gnm2.ann1.5FB4.cds.fna.gz
-  FAM_data/lotja.MG20.gnm3.ann1.WF9B.cds_primary.fna.gz
-  FAM_data/lupal.Amiga.gnm1.ann1.3GKS.cds.fna.gz
-  FAM_data/Medicago.pan2.451K.pctl25_named_cds.fna.gz
-  FAM_data/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
-  FAM_data/pissa.Cameor.gnm1.ann1.7SZR.cds_primary.fna.gz
-  FAM_data/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
-  FAM_data/sento.Myeongyun.gnm1.ann1.cds.fna.gz
-  FAM_data/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
-  FAM_data/vicfa.Hedin2.gnm1.ann1.PTNK.cds_primary.fna.gz
-  FAM_data/Vigna.pan2.MQQM.pctl25_named_cds.fna.gz
+  data/aesev.CIAT22838.gnm1.ann1.ZM3R.cds_primary.fna.gz
+  data/Arachis.pan2.5P1K.pctl40_named_cds.fna.gz
+  data/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
+  data/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
+  data/Cicer.pan2.CMWZ.pctl25_named_cds.fna.gz
+  data/dalod.SKLTGB.gnm1.ann1.R67B.cds.fna.gz
+  data/Glycine.pan4.RK4P.pctl25_named_cds.fna.gz
+  data/lencu.CDC_Redberry.gnm2.ann1.5FB4.cds.fna.gz
+  data/lotja.MG20.gnm3.ann1.WF9B.cds_primary.fna.gz
+  data/lupal.Amiga.gnm1.ann1.3GKS.cds.fna.gz
+  data/Medicago.pan2.451K.pctl25_named_cds.fna.gz
+  data/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
+  data/pissa.Cameor.gnm1.ann1.7SZR.cds_primary.fna.gz
+  data/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
+  data/sento.Myeongyun.gnm1.ann1.cds.fna.gz
+  data/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
+  data/vicfa.Hedin2.gnm1.ann1.PTNK.cds_primary.fna.gz
+  data/Vigna.pan2.MQQM.pctl25_named_cds.fna.gz
 )
 
 ### (optional) Extra BED & FASTA files
 annotation_files_extra_free=(
-  FAM_data/arath.Col0.gnm9.ann11.KH24.protein.bed.gz
-  FAM_data/prupe.Lovell.gnm2.ann1.S2ZZ.protein.bed.gz
-  FAM_data/vitvi.PN40024.gnm2.ann1.V31M.protein.bed.gz
+  data/arath.Col0.gnm9.ann11.KH24.protein.bed.gz
+  data/prupe.Lovell.gnm2.ann1.S2ZZ.protein.bed.gz
+  data/vitvi.PN40024.gnm2.ann1.V31M.protein.bed.gz
 )
 
 cds_files_extra_free=(
-  FAM_data/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
-  FAM_data/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
-  FAM_data/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
+  data/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
+  data/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
+  data/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
 )
 
 protein_files_extra=(
-  FAM_data/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
-  FAM_data/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
-  FAM_data/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
+  data/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
+  data/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
+  data/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
 )

--- a/get_data/get_Arachis.sh
+++ b/get_data/get_Arachis.sh
@@ -49,7 +49,7 @@ zcat aradu.V14167.gnm1.ann1.cxSM.gene_models_main.bed.gz araip.K30076.gnm1.ann1.
             s/^araip.K30076.gnm1.Araip.B1(\d)/araduip.V14167K30076.gnm1.chrB2$1/;
             s/aradu.V14167.gnm1/araduip.V14167K30076.gnm1/;
             s/araip.K30076.gnm1/araduip.V14167K30076.gnm1/' |
-  cat > ../data/araduip.V14167K30076.gnm1.ann1.cxSMJ37m.cds.bed
+  cat > ../data/araduip.V14167K30076.gnm1.ann1.cxSMJ37m.gene_models_main.bed
 
 # Copy the arahy bed files
   for file in arahy*bed.gz; do 

--- a/get_data/get_Arachis.sh
+++ b/get_data/get_Arachis.sh
@@ -15,29 +15,29 @@ url_base="https://data.legumeinfo.org/Arachis"
 ## data
 base_dir=$PWD
 cd $base_dir/data_orig/
-curl -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.cds.fna.gz
-curl -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.cds_primary.fna.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.cds_primary.fna.gz
-curl -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.cds_primary.fna.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.cds_primary.fna.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.cds.fna.gz
-curl -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.cds.fna.gz
+curl -f -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.cds.fna.gz
+curl -f -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.cds_primary.fna.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.cds_primary.fna.gz
+curl -f -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.cds_primary.fna.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.cds_primary.fna.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.cds.fna.gz
+curl -f -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.cds.fna.gz
 
-curl -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.gene_models_main.bed.gz
-curl -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.gene_models_main.bed.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.gene_models_main.bed.gz
-curl -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.gene_models_main.bed.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.gene_models_main.bed.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.gene_models_main.bed.gz
-curl -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.gene_models_main.bed.gz
+curl -f -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.gene_models_main.bed.gz
+curl -f -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.gene_models_main.bed.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.gene_models_main.bed.gz
+curl -f -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.gene_models_main.bed.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.gene_models_main.bed.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.gene_models_main.bed.gz
+curl -f -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.gene_models_main.bed.gz
 
-curl -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.protein.faa.gz
-curl -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.protein_primary.faa.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.protein_primary.faa.gz
-curl -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.protein_primary.faa.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.protein_primary.faa.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.protein.faa.gz
-curl -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.protein.faa.gz
+curl -f -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.protein.faa.gz
+curl -f -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.protein_primary.faa.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.protein_primary.faa.gz
+curl -f -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.protein_primary.faa.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.protein_primary.faa.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.protein.faa.gz
+curl -f -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.protein.faa.gz
 
 
 # Merge duranensis and ipaensis to give a pseudo-allotetraploid that can be compared with A. hypogaea
@@ -92,7 +92,7 @@ zcat aradu.V14167.gnm1.ann1.cxSM.gene_models_main.bed.gz araip.K30076.gnm1.ann1.
 
 # Exclude 145 models that weren't mapped from Tifrunner.gnm1.ann1 to Tifrunner.gnm2.ann1:
 url_base="https://data.legumeinfo.org/Arachis"
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.info_unmapped_models.txt.gz
+curl -f -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.info_unmapped_models.txt.gz
 
   zcat arahy.Tifrunner.gnm2.ann1.4K0L.info_unmapped_models.txt.gz | awk '$1!~/^#/ {print $1}' |
     perl -pe 's/arahy.Tifrunner.gnm1.ann1/arahy.Tifrunner.gnm2.ann1/' > lis.exclude_from_arahy.Tifrunner.gnm2.ann1

--- a/get_data/get_Arachis.sh
+++ b/get_data/get_Arachis.sh
@@ -23,13 +23,13 @@ curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.
 curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.cds.fna.gz
 curl -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.cds.fna.gz
 
-curl -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.cds.bed.gz
-curl -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.cds.bed.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.cds.bed.gz
-curl -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.cds.bed.gz
-curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.cds.bed.gz
+curl -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.gene_models_main.bed.gz
+curl -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.gene_models_main.bed.gz
+curl -O $url_base/hypogaea/annotations/Tifrunner.gnm1.ann1.CCJH/arahy.Tifrunner.gnm1.ann1.CCJH.gene_models_main.bed.gz
+curl -O https://data.legumeinfo.org/annex/Arachis/hypogaea/annotations/Tifrunner.gnm1.ann2.TN8K/arahy.Tifrunner.gnm1.ann2.TN8K.gene_models_main.bed.gz
+curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann1.4K0L/arahy.Tifrunner.gnm2.ann1.4K0L.gene_models_main.bed.gz
 curl -O $url_base/hypogaea/annotations/Tifrunner.gnm2.ann2.PVFB/arahy.Tifrunner.gnm2.ann2.PVFB.gene_models_main.bed.gz
-curl -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.cds.bed.gz
+curl -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.ann1.J37m.gene_models_main.bed.gz
 
 curl -O $url_base/duranensis/annotations/V14167.gnm1.ann1.cxSM/aradu.V14167.gnm1.ann1.cxSM.protein.faa.gz
 curl -O $url_base/hypogaea/annotations/BaileyII.gnm1.ann1.PQM7/arahy.BaileyII.gnm1.ann1.PQM7.protein_primary.faa.gz
@@ -41,7 +41,7 @@ curl -O $url_base/ipaensis/annotations/K30076.gnm1.ann1.J37m/araip.K30076.gnm1.a
 
 
 # Merge duranensis and ipaensis to give a pseudo-allotetraploid that can be compared with A. hypogaea
-zcat aradu.V14167.gnm1.ann1.cxSM.cds.bed.gz araip.K30076.gnm1.ann1.J37m.cds.bed.gz |
+zcat aradu.V14167.gnm1.ann1.cxSM.gene_models_main.bed.gz araip.K30076.gnm1.ann1.J37m.gene_models_main.bed.gz |
   perl -pe 's/aradu.V14167.gnm1.Adur/araduip.V14167K30076.gnm1.scaffA_/; 
             s/araip.K30076.gnm1.Aipa/araduip.V14167K30076.gnm1.scaffB_/; 
             s/aradu.V14167.gnm1.Aradu.A/araduip.V14167K30076.gnm1.chrA/;
@@ -110,6 +110,8 @@ cd $base_dir/data/
 
 for file in *; do gzip $file &
 done
+
+wait
 
 cat <<DATA > expected_chr_matches.tsv
 # Expected chromosome matches for Arachis

--- a/get_data/get_Cicer.sh
+++ b/get_data/get_Cicer.sh
@@ -16,26 +16,26 @@ url_base="https://data.legumeinfo.org/Cicer"
 base_dir=$PWD
 cd $base_dir/data/
 
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.gene_models_main.bed.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.gene_models_main.bed.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.gene_models_main.bed.gz
-curl -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.gene_models_main.bed.gz
-curl -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.gene_models_main.bed.gz
-curl -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.gene_models_main.bed.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.gene_models_main.bed.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.gene_models_main.bed.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.gene_models_main.bed.gz
+curl -f -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.gene_models_main.bed.gz
+curl -f -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.gene_models_main.bed.gz
+curl -f -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.gene_models_main.bed.gz
 
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.cds.fna.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.cds_primary.fna.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.cds.fna.gz
-curl -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.cds_primary.fna.gz
-curl -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.cds.fna.gz
-curl -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.cds.fna.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.cds.fna.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.cds_primary.fna.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.cds.fna.gz
+curl -f -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.cds_primary.fna.gz
+curl -f -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.cds.fna.gz
+curl -f -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.cds.fna.gz
 
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.protein.faa.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.protein_primary.faa.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.protein.faa.gz
-curl -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.protein_primary.faa.gz
-curl -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.protein.faa.gz
-curl -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.protein.faa.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.protein.faa.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.protein_primary.faa.gz
+curl -f -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.protein.faa.gz
+curl -f -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.protein_primary.faa.gz
+curl -f -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.protein.faa.gz
+curl -f -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.protein.faa.gz
 
 # Fix the forms of chromosome IDs, if necessary
   # Not necessary for Cicer

--- a/get_data/get_Cicer.sh
+++ b/get_data/get_Cicer.sh
@@ -16,12 +16,12 @@ url_base="https://data.legumeinfo.org/Cicer"
 base_dir=$PWD
 cd $base_dir/data/
 
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.cds.bed.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.cds.bed.gz
-curl -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.cds.bed.gz
-curl -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.cds.bed.gz
-curl -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.cds.bed.gz
-curl -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.cds.bed.gz
+curl -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.gene_models_main.bed.gz
+curl -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.gene_models_main.bed.gz
+curl -O $url_base/arietinum/annotations/CDCFrontier.gnm3.ann1.NPD7/cicar.CDCFrontier.gnm3.ann1.NPD7.gene_models_main.bed.gz
+curl -O $url_base/arietinum/annotations/ICC4958.gnm2.ann1.LCVX/cicar.ICC4958.gnm2.ann1.LCVX.gene_models_main.bed.gz
+curl -O $url_base/echinospermum/annotations/S2Drd065.gnm1.ann1.YZ9H/cicec.S2Drd065.gnm1.ann1.YZ9H.gene_models_main.bed.gz
+curl -O $url_base/reticulatum/annotations/Besev079.gnm1.ann1.F01Z/cicre.Besev079.gnm1.ann1.F01Z.gene_models_main.bed.gz
 
 curl -O $url_base/arietinum/annotations/CDCFrontier.gnm1.ann1.nRhs/cicar.CDCFrontier.gnm1.ann1.nRhs.cds.fna.gz
 curl -O $url_base/arietinum/annotations/CDCFrontier.gnm2.ann1.9M1L/cicar.CDCFrontier.gnm2.ann1.9M1L.cds_primary.fna.gz

--- a/get_data/get_Glycine.sh
+++ b/get_data/get_Glycine.sh
@@ -17,178 +17,178 @@ base_dir=$PWD
 cd $base_dir/data/
 
 # CDS
-curl -O $url_base/max/annotations/58-161.gnm1.ann1.HJ1K/glyma.58-161.gnm1.ann1.HJ1K.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Amsoy.gnm1.ann1.6S5P/glyma.Amsoy.gnm1.ann1.6S5P.cds_primary.fna.gz
-curl -O $url_base/max/annotations/DongNongNo_50.gnm1.ann1.QSDB/glyma.DongNongNo_50.gnm1.ann1.QSDB.cds_primary.fna.gz
-curl -O $url_base/max/annotations/FengDiHuang.gnm1.ann1.P6HL/glyma.FengDiHuang.gnm1.ann1.P6HL.cds_primary.fna.gz
-curl -O $url_base/max/annotations/FiskebyIII.gnm1.ann1.SS25/glyma.FiskebyIII.gnm1.ann1.SS25.cds_primary.fna.gz
-curl -O $url_base/max/annotations/HanDouNo_5.gnm1.ann1.ZS7M/glyma.HanDouNo_5.gnm1.ann1.ZS7M.cds_primary.fna.gz
-curl -O $url_base/max/annotations/HeiHeNo_43.gnm1.ann1.PDXG/glyma.HeiHeNo_43.gnm1.ann1.PDXG.cds_primary.fna.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.cds_primary.fna.gz
-curl -O $url_base/max/annotations/JiDouNo_17.gnm1.ann1.X5PX/glyma.JiDouNo_17.gnm1.ann1.X5PX.cds_primary.fna.gz
-curl -O $url_base/max/annotations/JinDouNo_23.gnm1.ann1.SGJW/glyma.JinDouNo_23.gnm1.ann1.SGJW.cds_primary.fna.gz
-curl -O $url_base/max/annotations/JuXuanNo_23.gnm1.ann1.H8PW/glyma.JuXuanNo_23.gnm1.ann1.H8PW.cds_primary.fna.gz
-curl -O $url_base/max/annotations/KeShanNo_1.gnm1.ann1.2YX4/glyma.KeShanNo_1.gnm1.ann1.2YX4.cds_primary.fna.gz
-curl -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.cds_primary.fna.gz
-curl -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.cds_primary.fna.gz
-curl -O $url_base/max/annotations/QiHuangNo_34.gnm1.ann1.WHRV/glyma.QiHuangNo_34.gnm1.ann1.WHRV.cds_primary.fna.gz
-curl -O $url_base/max/annotations/ShiShengChangYe.gnm1.ann1.VLGS/glyma.ShiShengChangYe.gnm1.ann1.VLGS.cds_primary.fna.gz
-curl -O $url_base/max/annotations/TieFengNo_18.gnm1.ann1.7GR4/glyma.TieFengNo_18.gnm1.ann1.7GR4.cds_primary.fna.gz
-curl -O $url_base/max/annotations/TieJiaSiLiHuang.gnm1.ann1.W70Z/glyma.TieJiaSiLiHuang.gnm1.ann1.W70Z.cds_primary.fna.gz
-curl -O $url_base/max/annotations/TongShanTianEDan.gnm1.ann1.56XW/glyma.TongShanTianEDan.gnm1.ann1.56XW.cds_primary.fna.gz
-curl -O $url_base/max/annotations/WanDouNo_28.gnm1.ann1.NLYP/glyma.WanDouNo_28.gnm1.ann1.NLYP.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Wm82_ISU01.gnm2.ann1.FGFB/glyma.Wm82_ISU01.gnm2.ann1.FGFB.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.cds_primary.fna.gz
-curl -O $url_base/max/annotations/XuDouNo_1.gnm1.ann1.G2T7/glyma.XuDouNo_1.gnm1.ann1.G2T7.cds_primary.fna.gz
-curl -O $url_base/max/annotations/YuDouNo_22.gnm1.ann1.HCQ1/glyma.YuDouNo_22.gnm1.ann1.HCQ1.cds_primary.fna.gz
-curl -O $url_base/max/annotations/ZhangChunManCangJin.gnm1.ann1.7HPB/glyma.ZhangChunManCangJin.gnm1.ann1.7HPB.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Zhutwinning2.gnm1.ann1.ZTTQ/glyma.Zhutwinning2.gnm1.ann1.ZTTQ.cds_primary.fna.gz
-curl -O $url_base/max/annotations/ZiHuaNo_4.gnm1.ann1.FCFQ/glyma.ZiHuaNo_4.gnm1.ann1.FCFQ.cds_primary.fna.gz
-curl -O $url_base/soja/annotations/PI_549046.gnm1.ann1.65KD/glyso.PI_549046.gnm1.ann1.65KD.cds_primary.fna.gz
-curl -O $url_base/soja/annotations/PI_562565.gnm1.ann1.1JD2/glyso.PI_562565.gnm1.ann1.1JD2.cds_primary.fna.gz
-curl -O $url_base/soja/annotations/PI_578357.gnm1.ann1.0ZKP/glyso.PI_578357.gnm1.ann1.0ZKP.cds_primary.fna.gz
-curl -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/58-161.gnm1.ann1.HJ1K/glyma.58-161.gnm1.ann1.HJ1K.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Amsoy.gnm1.ann1.6S5P/glyma.Amsoy.gnm1.ann1.6S5P.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/DongNongNo_50.gnm1.ann1.QSDB/glyma.DongNongNo_50.gnm1.ann1.QSDB.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/FengDiHuang.gnm1.ann1.P6HL/glyma.FengDiHuang.gnm1.ann1.P6HL.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/FiskebyIII.gnm1.ann1.SS25/glyma.FiskebyIII.gnm1.ann1.SS25.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/HanDouNo_5.gnm1.ann1.ZS7M/glyma.HanDouNo_5.gnm1.ann1.ZS7M.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/HeiHeNo_43.gnm1.ann1.PDXG/glyma.HeiHeNo_43.gnm1.ann1.PDXG.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/JiDouNo_17.gnm1.ann1.X5PX/glyma.JiDouNo_17.gnm1.ann1.X5PX.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/JinDouNo_23.gnm1.ann1.SGJW/glyma.JinDouNo_23.gnm1.ann1.SGJW.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/JuXuanNo_23.gnm1.ann1.H8PW/glyma.JuXuanNo_23.gnm1.ann1.H8PW.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/KeShanNo_1.gnm1.ann1.2YX4/glyma.KeShanNo_1.gnm1.ann1.2YX4.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/QiHuangNo_34.gnm1.ann1.WHRV/glyma.QiHuangNo_34.gnm1.ann1.WHRV.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/ShiShengChangYe.gnm1.ann1.VLGS/glyma.ShiShengChangYe.gnm1.ann1.VLGS.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/TieFengNo_18.gnm1.ann1.7GR4/glyma.TieFengNo_18.gnm1.ann1.7GR4.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/TieJiaSiLiHuang.gnm1.ann1.W70Z/glyma.TieJiaSiLiHuang.gnm1.ann1.W70Z.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/TongShanTianEDan.gnm1.ann1.56XW/glyma.TongShanTianEDan.gnm1.ann1.56XW.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/WanDouNo_28.gnm1.ann1.NLYP/glyma.WanDouNo_28.gnm1.ann1.NLYP.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Wm82_ISU01.gnm2.ann1.FGFB/glyma.Wm82_ISU01.gnm2.ann1.FGFB.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/XuDouNo_1.gnm1.ann1.G2T7/glyma.XuDouNo_1.gnm1.ann1.G2T7.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/YuDouNo_22.gnm1.ann1.HCQ1/glyma.YuDouNo_22.gnm1.ann1.HCQ1.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/ZhangChunManCangJin.gnm1.ann1.7HPB/glyma.ZhangChunManCangJin.gnm1.ann1.7HPB.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Zhutwinning2.gnm1.ann1.ZTTQ/glyma.Zhutwinning2.gnm1.ann1.ZTTQ.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/ZiHuaNo_4.gnm1.ann1.FCFQ/glyma.ZiHuaNo_4.gnm1.ann1.FCFQ.cds_primary.fna.gz
+curl -f -O $url_base/soja/annotations/PI_549046.gnm1.ann1.65KD/glyso.PI_549046.gnm1.ann1.65KD.cds_primary.fna.gz
+curl -f -O $url_base/soja/annotations/PI_562565.gnm1.ann1.1JD2/glyso.PI_562565.gnm1.ann1.1JD2.cds_primary.fna.gz
+curl -f -O $url_base/soja/annotations/PI_578357.gnm1.ann1.0ZKP/glyso.PI_578357.gnm1.ann1.0ZKP.cds_primary.fna.gz
+curl -f -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.cds_primary.fna.gz
 
-curl -O $url_base/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.cds.fna.gz
-curl -O $url_base/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.cds.fna.gz
-curl -O $url_base/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.cds.fna.gz
-curl -O $url_base/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.cds.fna.gz
-curl -O $url_base/max/annotations/Hefeng25_IGA1002.gnm1.ann1.320V/glyma.Hefeng25_IGA1002.gnm1.ann1.320V.cds.fna.gz
-curl -O $url_base/max/annotations/Huaxia3_IGA1007.gnm1.ann1.LKC7/glyma.Huaxia3_IGA1007.gnm1.ann1.LKC7.cds.fna.gz
-curl -O $url_base/max/annotations/Hwangkeum.gnm1.ann1.1G4F/glyma.Hwangkeum.gnm1.ann1.1G4F.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.cds.fna.gz
-curl -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Lee.gnm2.ann1.1FNT/glyma.Lee.gnm2.ann1.1FNT.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Wenfeng7_IGA1001.gnm1.ann1.ZK5W/glyma.Wenfeng7_IGA1001.gnm1.ann1.ZK5W.cds.fna.gz
-curl -O $url_base/max/annotations/Wm82_IGA1008.gnm1.ann1.FGN6/glyma.Wm82_IGA1008.gnm1.ann1.FGN6.cds.fna.gz
-curl -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Zh13_IGA1005.gnm1.ann1.87Z5/glyma.Zh13_IGA1005.gnm1.ann1.87Z5.cds.fna.gz
-curl -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Zh13.gnm2.ann1.FJ3G/glyma.Zh13.gnm2.ann1.FJ3G.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.cds.fna.gz
-curl -O $url_base/soja/annotations/F_IGA1003.gnm1.ann1.G61B/glyso.F_IGA1003.gnm1.ann1.G61B.cds.fna.gz
-curl -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.cds_primary.fna.gz
-curl -O $url_base/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.cds.fna.gz
-curl -O $url_base/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.cds.fna.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.cds.fna.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.cds.fna.gz
+curl -f -O $url_base/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.cds.fna.gz
+curl -f -O $url_base/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.cds.fna.gz
+curl -f -O $url_base/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.cds.fna.gz
+curl -f -O $url_base/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.cds.fna.gz
+curl -f -O $url_base/max/annotations/Hefeng25_IGA1002.gnm1.ann1.320V/glyma.Hefeng25_IGA1002.gnm1.ann1.320V.cds.fna.gz
+curl -f -O $url_base/max/annotations/Huaxia3_IGA1007.gnm1.ann1.LKC7/glyma.Huaxia3_IGA1007.gnm1.ann1.LKC7.cds.fna.gz
+curl -f -O $url_base/max/annotations/Hwangkeum.gnm1.ann1.1G4F/glyma.Hwangkeum.gnm1.ann1.1G4F.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.cds.fna.gz
+curl -f -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Lee.gnm2.ann1.1FNT/glyma.Lee.gnm2.ann1.1FNT.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Wenfeng7_IGA1001.gnm1.ann1.ZK5W/glyma.Wenfeng7_IGA1001.gnm1.ann1.ZK5W.cds.fna.gz
+curl -f -O $url_base/max/annotations/Wm82_IGA1008.gnm1.ann1.FGN6/glyma.Wm82_IGA1008.gnm1.ann1.FGN6.cds.fna.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Zh13_IGA1005.gnm1.ann1.87Z5/glyma.Zh13_IGA1005.gnm1.ann1.87Z5.cds.fna.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm2.ann1.FJ3G/glyma.Zh13.gnm2.ann1.FJ3G.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.cds.fna.gz
+curl -f -O $url_base/soja/annotations/F_IGA1003.gnm1.ann1.G61B/glyso.F_IGA1003.gnm1.ann1.G61B.cds.fna.gz
+curl -f -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.cds_primary.fna.gz
+curl -f -O $url_base/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.cds.fna.gz
+curl -f -O $url_base/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.cds.fna.gz
+curl -f -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.cds.fna.gz
+curl -f -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.cds.fna.gz
 
 # BED
-curl -O $url_base/max/annotations/58-161.gnm1.ann1.HJ1K/glyma.58-161.gnm1.ann1.HJ1K.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Amsoy.gnm1.ann1.6S5P/glyma.Amsoy.gnm1.ann1.6S5P.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/DongNongNo_50.gnm1.ann1.QSDB/glyma.DongNongNo_50.gnm1.ann1.QSDB.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/FengDiHuang.gnm1.ann1.P6HL/glyma.FengDiHuang.gnm1.ann1.P6HL.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/FiskebyIII.gnm1.ann1.SS25/glyma.FiskebyIII.gnm1.ann1.SS25.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/HanDouNo_5.gnm1.ann1.ZS7M/glyma.HanDouNo_5.gnm1.ann1.ZS7M.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/HeiHeNo_43.gnm1.ann1.PDXG/glyma.HeiHeNo_43.gnm1.ann1.PDXG.gene_models_main.bed.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/JiDouNo_17.gnm1.ann1.X5PX/glyma.JiDouNo_17.gnm1.ann1.X5PX.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/JinDouNo_23.gnm1.ann1.SGJW/glyma.JinDouNo_23.gnm1.ann1.SGJW.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/JuXuanNo_23.gnm1.ann1.H8PW/glyma.JuXuanNo_23.gnm1.ann1.H8PW.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/KeShanNo_1.gnm1.ann1.2YX4/glyma.KeShanNo_1.gnm1.ann1.2YX4.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/QiHuangNo_34.gnm1.ann1.WHRV/glyma.QiHuangNo_34.gnm1.ann1.WHRV.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/ShiShengChangYe.gnm1.ann1.VLGS/glyma.ShiShengChangYe.gnm1.ann1.VLGS.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/TieFengNo_18.gnm1.ann1.7GR4/glyma.TieFengNo_18.gnm1.ann1.7GR4.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/TieJiaSiLiHuang.gnm1.ann1.W70Z/glyma.TieJiaSiLiHuang.gnm1.ann1.W70Z.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/TongShanTianEDan.gnm1.ann1.56XW/glyma.TongShanTianEDan.gnm1.ann1.56XW.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/WanDouNo_28.gnm1.ann1.NLYP/glyma.WanDouNo_28.gnm1.ann1.NLYP.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Wm82_ISU01.gnm2.ann1.FGFB/glyma.Wm82_ISU01.gnm2.ann1.FGFB.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/XuDouNo_1.gnm1.ann1.G2T7/glyma.XuDouNo_1.gnm1.ann1.G2T7.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/YuDouNo_22.gnm1.ann1.HCQ1/glyma.YuDouNo_22.gnm1.ann1.HCQ1.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/ZhangChunManCangJin.gnm1.ann1.7HPB/glyma.ZhangChunManCangJin.gnm1.ann1.7HPB.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Zhutwinning2.gnm1.ann1.ZTTQ/glyma.Zhutwinning2.gnm1.ann1.ZTTQ.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/ZiHuaNo_4.gnm1.ann1.FCFQ/glyma.ZiHuaNo_4.gnm1.ann1.FCFQ.gene_models_main.bed.gz
-curl -O $url_base/soja/annotations/PI_549046.gnm1.ann1.65KD/glyso.PI_549046.gnm1.ann1.65KD.gene_models_main.bed.gz
-curl -O $url_base/soja/annotations/PI_562565.gnm1.ann1.1JD2/glyso.PI_562565.gnm1.ann1.1JD2.gene_models_main.bed.gz
-curl -O $url_base/soja/annotations/PI_578357.gnm1.ann1.0ZKP/glyso.PI_578357.gnm1.ann1.0ZKP.gene_models_main.bed.gz
-curl -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/58-161.gnm1.ann1.HJ1K/glyma.58-161.gnm1.ann1.HJ1K.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Amsoy.gnm1.ann1.6S5P/glyma.Amsoy.gnm1.ann1.6S5P.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/DongNongNo_50.gnm1.ann1.QSDB/glyma.DongNongNo_50.gnm1.ann1.QSDB.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/FengDiHuang.gnm1.ann1.P6HL/glyma.FengDiHuang.gnm1.ann1.P6HL.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/FiskebyIII.gnm1.ann1.SS25/glyma.FiskebyIII.gnm1.ann1.SS25.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/HanDouNo_5.gnm1.ann1.ZS7M/glyma.HanDouNo_5.gnm1.ann1.ZS7M.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/HeiHeNo_43.gnm1.ann1.PDXG/glyma.HeiHeNo_43.gnm1.ann1.PDXG.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/JiDouNo_17.gnm1.ann1.X5PX/glyma.JiDouNo_17.gnm1.ann1.X5PX.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/JinDouNo_23.gnm1.ann1.SGJW/glyma.JinDouNo_23.gnm1.ann1.SGJW.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/JuXuanNo_23.gnm1.ann1.H8PW/glyma.JuXuanNo_23.gnm1.ann1.H8PW.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/KeShanNo_1.gnm1.ann1.2YX4/glyma.KeShanNo_1.gnm1.ann1.2YX4.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/QiHuangNo_34.gnm1.ann1.WHRV/glyma.QiHuangNo_34.gnm1.ann1.WHRV.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/ShiShengChangYe.gnm1.ann1.VLGS/glyma.ShiShengChangYe.gnm1.ann1.VLGS.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/TieFengNo_18.gnm1.ann1.7GR4/glyma.TieFengNo_18.gnm1.ann1.7GR4.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/TieJiaSiLiHuang.gnm1.ann1.W70Z/glyma.TieJiaSiLiHuang.gnm1.ann1.W70Z.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/TongShanTianEDan.gnm1.ann1.56XW/glyma.TongShanTianEDan.gnm1.ann1.56XW.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/WanDouNo_28.gnm1.ann1.NLYP/glyma.WanDouNo_28.gnm1.ann1.NLYP.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Wm82_ISU01.gnm2.ann1.FGFB/glyma.Wm82_ISU01.gnm2.ann1.FGFB.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/XuDouNo_1.gnm1.ann1.G2T7/glyma.XuDouNo_1.gnm1.ann1.G2T7.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/YuDouNo_22.gnm1.ann1.HCQ1/glyma.YuDouNo_22.gnm1.ann1.HCQ1.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/ZhangChunManCangJin.gnm1.ann1.7HPB/glyma.ZhangChunManCangJin.gnm1.ann1.7HPB.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Zhutwinning2.gnm1.ann1.ZTTQ/glyma.Zhutwinning2.gnm1.ann1.ZTTQ.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/ZiHuaNo_4.gnm1.ann1.FCFQ/glyma.ZiHuaNo_4.gnm1.ann1.FCFQ.gene_models_main.bed.gz
+curl -f -O $url_base/soja/annotations/PI_549046.gnm1.ann1.65KD/glyso.PI_549046.gnm1.ann1.65KD.gene_models_main.bed.gz
+curl -f -O $url_base/soja/annotations/PI_562565.gnm1.ann1.1JD2/glyso.PI_562565.gnm1.ann1.1JD2.gene_models_main.bed.gz
+curl -f -O $url_base/soja/annotations/PI_578357.gnm1.ann1.0ZKP/glyso.PI_578357.gnm1.ann1.0ZKP.gene_models_main.bed.gz
+curl -f -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.gene_models_main.bed.gz
 
-curl -O $url_base/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.gene_models_main.bed.gz
-curl -O $url_base/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.gene_models_main.bed.gz
-curl -O $url_base/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.gene_models_main.bed.gz
-curl -O $url_base/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Hefeng25_IGA1002.gnm1.ann1.320V/glyma.Hefeng25_IGA1002.gnm1.ann1.320V.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Huaxia3_IGA1007.gnm1.ann1.LKC7/glyma.Huaxia3_IGA1007.gnm1.ann1.LKC7.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Hwangkeum.gnm1.ann1.1G4F/glyma.Hwangkeum.gnm1.ann1.1G4F.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Lee.gnm2.ann1.1FNT/glyma.Lee.gnm2.ann1.1FNT.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Wenfeng7_IGA1001.gnm1.ann1.ZK5W/glyma.Wenfeng7_IGA1001.gnm1.ann1.ZK5W.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Wm82_IGA1008.gnm1.ann1.FGN6/glyma.Wm82_IGA1008.gnm1.ann1.FGN6.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Zh13_IGA1005.gnm1.ann1.87Z5/glyma.Zh13_IGA1005.gnm1.ann1.87Z5.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Zh13.gnm2.ann1.FJ3G/glyma.Zh13.gnm2.ann1.FJ3G.gene_models_main.bed.gz
-curl -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.gene_models_main.bed.gz
-curl -O $url_base/soja/annotations/F_IGA1003.gnm1.ann1.G61B/glyso.F_IGA1003.gnm1.ann1.G61B.gene_models_main.bed.gz
-curl -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.gene_models_main.bed.gz
-curl -O $url_base/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.gene_models_main.bed.gz
-curl -O $url_base/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.gene_models_main.bed.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.gene_models_main.bed.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.gene_models_main.bed.gz
+curl -f -O $url_base/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.gene_models_main.bed.gz
+curl -f -O $url_base/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.gene_models_main.bed.gz
+curl -f -O $url_base/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.gene_models_main.bed.gz
+curl -f -O $url_base/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Hefeng25_IGA1002.gnm1.ann1.320V/glyma.Hefeng25_IGA1002.gnm1.ann1.320V.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Huaxia3_IGA1007.gnm1.ann1.LKC7/glyma.Huaxia3_IGA1007.gnm1.ann1.LKC7.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Hwangkeum.gnm1.ann1.1G4F/glyma.Hwangkeum.gnm1.ann1.1G4F.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Lee.gnm2.ann1.1FNT/glyma.Lee.gnm2.ann1.1FNT.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Wenfeng7_IGA1001.gnm1.ann1.ZK5W/glyma.Wenfeng7_IGA1001.gnm1.ann1.ZK5W.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Wm82_IGA1008.gnm1.ann1.FGN6/glyma.Wm82_IGA1008.gnm1.ann1.FGN6.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Zh13_IGA1005.gnm1.ann1.87Z5/glyma.Zh13_IGA1005.gnm1.ann1.87Z5.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm2.ann1.FJ3G/glyma.Zh13.gnm2.ann1.FJ3G.gene_models_main.bed.gz
+curl -f -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.gene_models_main.bed.gz
+curl -f -O $url_base/soja/annotations/F_IGA1003.gnm1.ann1.G61B/glyso.F_IGA1003.gnm1.ann1.G61B.gene_models_main.bed.gz
+curl -f -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.gene_models_main.bed.gz
+curl -f -O $url_base/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.gene_models_main.bed.gz
+curl -f -O $url_base/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.gene_models_main.bed.gz
+curl -f -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.gene_models_main.bed.gz
+curl -f -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.gene_models_main.bed.gz
 
 # Protein
-curl -O $url_base/max/annotations/58-161.gnm1.ann1.HJ1K/glyma.58-161.gnm1.ann1.HJ1K.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Amsoy.gnm1.ann1.6S5P/glyma.Amsoy.gnm1.ann1.6S5P.protein_primary.faa.gz
-curl -O $url_base/max/annotations/DongNongNo_50.gnm1.ann1.QSDB/glyma.DongNongNo_50.gnm1.ann1.QSDB.protein_primary.faa.gz
-curl -O $url_base/max/annotations/FengDiHuang.gnm1.ann1.P6HL/glyma.FengDiHuang.gnm1.ann1.P6HL.protein_primary.faa.gz
-curl -O $url_base/max/annotations/FiskebyIII.gnm1.ann1.SS25/glyma.FiskebyIII.gnm1.ann1.SS25.protein_primary.faa.gz
-curl -O $url_base/max/annotations/HanDouNo_5.gnm1.ann1.ZS7M/glyma.HanDouNo_5.gnm1.ann1.ZS7M.protein_primary.faa.gz
-curl -O $url_base/max/annotations/HeiHeNo_43.gnm1.ann1.PDXG/glyma.HeiHeNo_43.gnm1.ann1.PDXG.protein_primary.faa.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.protein_primary.faa.gz
-curl -O $url_base/max/annotations/JiDouNo_17.gnm1.ann1.X5PX/glyma.JiDouNo_17.gnm1.ann1.X5PX.protein_primary.faa.gz
-curl -O $url_base/max/annotations/JinDouNo_23.gnm1.ann1.SGJW/glyma.JinDouNo_23.gnm1.ann1.SGJW.protein_primary.faa.gz
-curl -O $url_base/max/annotations/JuXuanNo_23.gnm1.ann1.H8PW/glyma.JuXuanNo_23.gnm1.ann1.H8PW.protein_primary.faa.gz
-curl -O $url_base/max/annotations/KeShanNo_1.gnm1.ann1.2YX4/glyma.KeShanNo_1.gnm1.ann1.2YX4.protein_primary.faa.gz
-curl -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.protein_primary.faa.gz
-curl -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.protein_primary.faa.gz
-curl -O $url_base/max/annotations/QiHuangNo_34.gnm1.ann1.WHRV/glyma.QiHuangNo_34.gnm1.ann1.WHRV.protein_primary.faa.gz
-curl -O $url_base/max/annotations/ShiShengChangYe.gnm1.ann1.VLGS/glyma.ShiShengChangYe.gnm1.ann1.VLGS.protein_primary.faa.gz
-curl -O $url_base/max/annotations/TieFengNo_18.gnm1.ann1.7GR4/glyma.TieFengNo_18.gnm1.ann1.7GR4.protein_primary.faa.gz
-curl -O $url_base/max/annotations/TieJiaSiLiHuang.gnm1.ann1.W70Z/glyma.TieJiaSiLiHuang.gnm1.ann1.W70Z.protein_primary.faa.gz
-curl -O $url_base/max/annotations/TongShanTianEDan.gnm1.ann1.56XW/glyma.TongShanTianEDan.gnm1.ann1.56XW.protein_primary.faa.gz
-curl -O $url_base/max/annotations/WanDouNo_28.gnm1.ann1.NLYP/glyma.WanDouNo_28.gnm1.ann1.NLYP.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Wm82_ISU01.gnm2.ann1.FGFB/glyma.Wm82_ISU01.gnm2.ann1.FGFB.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.protein_primary.faa.gz
-curl -O $url_base/max/annotations/XuDouNo_1.gnm1.ann1.G2T7/glyma.XuDouNo_1.gnm1.ann1.G2T7.protein_primary.faa.gz
-curl -O $url_base/max/annotations/YuDouNo_22.gnm1.ann1.HCQ1/glyma.YuDouNo_22.gnm1.ann1.HCQ1.protein_primary.faa.gz
-curl -O $url_base/max/annotations/ZhangChunManCangJin.gnm1.ann1.7HPB/glyma.ZhangChunManCangJin.gnm1.ann1.7HPB.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Zhutwinning2.gnm1.ann1.ZTTQ/glyma.Zhutwinning2.gnm1.ann1.ZTTQ.protein_primary.faa.gz
-curl -O $url_base/max/annotations/ZiHuaNo_4.gnm1.ann1.FCFQ/glyma.ZiHuaNo_4.gnm1.ann1.FCFQ.protein_primary.faa.gz
-curl -O $url_base/soja/annotations/PI_549046.gnm1.ann1.65KD/glyso.PI_549046.gnm1.ann1.65KD.protein_primary.faa.gz
-curl -O $url_base/soja/annotations/PI_562565.gnm1.ann1.1JD2/glyso.PI_562565.gnm1.ann1.1JD2.protein_primary.faa.gz
-curl -O $url_base/soja/annotations/PI_578357.gnm1.ann1.0ZKP/glyso.PI_578357.gnm1.ann1.0ZKP.protein_primary.faa.gz
-curl -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/58-161.gnm1.ann1.HJ1K/glyma.58-161.gnm1.ann1.HJ1K.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Amsoy.gnm1.ann1.6S5P/glyma.Amsoy.gnm1.ann1.6S5P.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/DongNongNo_50.gnm1.ann1.QSDB/glyma.DongNongNo_50.gnm1.ann1.QSDB.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/FengDiHuang.gnm1.ann1.P6HL/glyma.FengDiHuang.gnm1.ann1.P6HL.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/FiskebyIII.gnm1.ann1.SS25/glyma.FiskebyIII.gnm1.ann1.SS25.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/HanDouNo_5.gnm1.ann1.ZS7M/glyma.HanDouNo_5.gnm1.ann1.ZS7M.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/HeiHeNo_43.gnm1.ann1.PDXG/glyma.HeiHeNo_43.gnm1.ann1.PDXG.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/JiDouNo_17.gnm1.ann1.X5PX/glyma.JiDouNo_17.gnm1.ann1.X5PX.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/JinDouNo_23.gnm1.ann1.SGJW/glyma.JinDouNo_23.gnm1.ann1.SGJW.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/JuXuanNo_23.gnm1.ann1.H8PW/glyma.JuXuanNo_23.gnm1.ann1.H8PW.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/KeShanNo_1.gnm1.ann1.2YX4/glyma.KeShanNo_1.gnm1.ann1.2YX4.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/QiHuangNo_34.gnm1.ann1.WHRV/glyma.QiHuangNo_34.gnm1.ann1.WHRV.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/ShiShengChangYe.gnm1.ann1.VLGS/glyma.ShiShengChangYe.gnm1.ann1.VLGS.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/TieFengNo_18.gnm1.ann1.7GR4/glyma.TieFengNo_18.gnm1.ann1.7GR4.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/TieJiaSiLiHuang.gnm1.ann1.W70Z/glyma.TieJiaSiLiHuang.gnm1.ann1.W70Z.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/TongShanTianEDan.gnm1.ann1.56XW/glyma.TongShanTianEDan.gnm1.ann1.56XW.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/WanDouNo_28.gnm1.ann1.NLYP/glyma.WanDouNo_28.gnm1.ann1.NLYP.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Wm82_ISU01.gnm2.ann1.FGFB/glyma.Wm82_ISU01.gnm2.ann1.FGFB.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/XuDouNo_1.gnm1.ann1.G2T7/glyma.XuDouNo_1.gnm1.ann1.G2T7.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/YuDouNo_22.gnm1.ann1.HCQ1/glyma.YuDouNo_22.gnm1.ann1.HCQ1.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/ZhangChunManCangJin.gnm1.ann1.7HPB/glyma.ZhangChunManCangJin.gnm1.ann1.7HPB.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Zhutwinning2.gnm1.ann1.ZTTQ/glyma.Zhutwinning2.gnm1.ann1.ZTTQ.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/ZiHuaNo_4.gnm1.ann1.FCFQ/glyma.ZiHuaNo_4.gnm1.ann1.FCFQ.protein_primary.faa.gz
+curl -f -O $url_base/soja/annotations/PI_549046.gnm1.ann1.65KD/glyso.PI_549046.gnm1.ann1.65KD.protein_primary.faa.gz
+curl -f -O $url_base/soja/annotations/PI_562565.gnm1.ann1.1JD2/glyso.PI_562565.gnm1.ann1.1JD2.protein_primary.faa.gz
+curl -f -O $url_base/soja/annotations/PI_578357.gnm1.ann1.0ZKP/glyso.PI_578357.gnm1.ann1.0ZKP.protein_primary.faa.gz
+curl -f -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.protein_primary.faa.gz
 
-curl -O $url_base/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.protein.faa.gz
-curl -O $url_base/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.protein.faa.gz
-curl -O $url_base/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.protein.faa.gz
-curl -O $url_base/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.protein.faa.gz
-curl -O $url_base/max/annotations/Hefeng25_IGA1002.gnm1.ann1.320V/glyma.Hefeng25_IGA1002.gnm1.ann1.320V.protein.faa.gz
-curl -O $url_base/max/annotations/Huaxia3_IGA1007.gnm1.ann1.LKC7/glyma.Huaxia3_IGA1007.gnm1.ann1.LKC7.protein.faa.gz
-curl -O $url_base/max/annotations/Hwangkeum.gnm1.ann1.1G4F/glyma.Hwangkeum.gnm1.ann1.1G4F.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.protein.faa.gz
-curl -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Lee.gnm2.ann1.1FNT/glyma.Lee.gnm2.ann1.1FNT.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Wenfeng7_IGA1001.gnm1.ann1.ZK5W/glyma.Wenfeng7_IGA1001.gnm1.ann1.ZK5W.protein.faa.gz
-curl -O $url_base/max/annotations/Wm82_IGA1008.gnm1.ann1.FGN6/glyma.Wm82_IGA1008.gnm1.ann1.FGN6.protein.faa.gz
-curl -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Zh13_IGA1005.gnm1.ann1.87Z5/glyma.Zh13_IGA1005.gnm1.ann1.87Z5.protein.faa.gz
-curl -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Zh13.gnm2.ann1.FJ3G/glyma.Zh13.gnm2.ann1.FJ3G.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.protein.faa.gz
-curl -O $url_base/soja/annotations/F_IGA1003.gnm1.ann1.G61B/glyso.F_IGA1003.gnm1.ann1.G61B.protein.faa.gz
-curl -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.protein_primary.faa.gz
-curl -O $url_base/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.protein.faa.gz
-curl -O $url_base/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.protein.faa.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.protein.faa.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.protein.faa.gz
+curl -f -O $url_base/cyrtoloba/annotations/G1267.gnm1.ann1.HRFD/glycy.G1267.gnm1.ann1.HRFD.protein.faa.gz
+curl -f -O $url_base/D3-tomentella/annotations/G1403.gnm1.ann1.XNZQ/glyd3.G1403.gnm1.ann1.XNZQ.protein.faa.gz
+curl -f -O $url_base/dolichocarpa/annotations/G1134.gnm1.ann1.4BJM/glydo.G1134.gnm1.ann1.4BJM.protein.faa.gz
+curl -f -O $url_base/falcata/annotations/G1718.gnm1.ann1.2KSV/glyfa.G1718.gnm1.ann1.2KSV.protein.faa.gz
+curl -f -O $url_base/max/annotations/Hefeng25_IGA1002.gnm1.ann1.320V/glyma.Hefeng25_IGA1002.gnm1.ann1.320V.protein.faa.gz
+curl -f -O $url_base/max/annotations/Huaxia3_IGA1007.gnm1.ann1.LKC7/glyma.Huaxia3_IGA1007.gnm1.ann1.LKC7.protein.faa.gz
+curl -f -O $url_base/max/annotations/Hwangkeum.gnm1.ann1.1G4F/glyma.Hwangkeum.gnm1.ann1.1G4F.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.protein.faa.gz
+curl -f -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Lee.gnm2.ann1.1FNT/glyma.Lee.gnm2.ann1.1FNT.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Wenfeng7_IGA1001.gnm1.ann1.ZK5W/glyma.Wenfeng7_IGA1001.gnm1.ann1.ZK5W.protein.faa.gz
+curl -f -O $url_base/max/annotations/Wm82_IGA1008.gnm1.ann1.FGN6/glyma.Wm82_IGA1008.gnm1.ann1.FGN6.protein.faa.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Zh13_IGA1005.gnm1.ann1.87Z5/glyma.Zh13_IGA1005.gnm1.ann1.87Z5.protein.faa.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm2.ann1.FJ3G/glyma.Zh13.gnm2.ann1.FJ3G.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.protein.faa.gz
+curl -f -O $url_base/soja/annotations/F_IGA1003.gnm1.ann1.G61B/glyso.F_IGA1003.gnm1.ann1.G61B.protein.faa.gz
+curl -f -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.protein_primary.faa.gz
+curl -f -O $url_base/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.protein.faa.gz
+curl -f -O $url_base/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.protein.faa.gz
+curl -f -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.protein.faa.gz
+curl -f -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.protein.faa.gz
 
 ## The glyma.Zh13.gnm2.ann1.FJ3G gene models are too big by half: N50 2376 vs. expected 1572 (Wm82.gnm4.ann1)
 ## Exclude glyma.Wm82.gnm2.ann2.BG1Q because the conversion between GFF and CDS was flawed as of mid-2022. Maybe add later.

--- a/get_data/get_Glycine.sh
+++ b/get_data/get_Glycine.sh
@@ -82,7 +82,7 @@ curl -O $url_base/max/annotations/FengDiHuang.gnm1.ann1.P6HL/glyma.FengDiHuang.g
 curl -O $url_base/max/annotations/FiskebyIII.gnm1.ann1.SS25/glyma.FiskebyIII.gnm1.ann1.SS25.gene_models_main.bed.gz
 curl -O $url_base/max/annotations/HanDouNo_5.gnm1.ann1.ZS7M/glyma.HanDouNo_5.gnm1.ann1.ZS7M.gene_models_main.bed.gz
 curl -O $url_base/max/annotations/HeiHeNo_43.gnm1.ann1.PDXG/glyma.HeiHeNo_43.gnm1.ann1.PDXG.gene_models_main.bed.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.cds.bed.gz
+curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.gene_models_main.bed.gz
 curl -O $url_base/max/annotations/JiDouNo_17.gnm1.ann1.X5PX/glyma.JiDouNo_17.gnm1.ann1.X5PX.gene_models_main.bed.gz
 curl -O $url_base/max/annotations/JinDouNo_23.gnm1.ann1.SGJW/glyma.JinDouNo_23.gnm1.ann1.SGJW.gene_models_main.bed.gz
 curl -O $url_base/max/annotations/JuXuanNo_23.gnm1.ann1.H8PW/glyma.JuXuanNo_23.gnm1.ann1.H8PW.gene_models_main.bed.gz
@@ -129,8 +129,8 @@ curl -O $url_base/soja/annotations/F_IGA1003.gnm1.ann1.G61B/glyso.F_IGA1003.gnm1
 curl -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.gene_models_main.bed.gz
 curl -O $url_base/stenophita/annotations/G1974.gnm1.ann1.F257/glyst.G1974.gnm1.ann1.F257.gene_models_main.bed.gz
 curl -O $url_base/syndetika/annotations/G1300.gnm1.ann1.RRK6/glysy.G1300.gnm1.ann1.RRK6.gene_models_main.bed.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.cds.bed.gz
-curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.cds.bed.gz
+curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Lee.gnm3.ann1.ZYY3/glyma.Lee.gnm3.ann1.ZYY3.gene_models_main.bed.gz
+curl -O https://data.legumeinfo.org/annex/Glycine/max/annotations/Wm82.gnm5.ann1.J7HW/glyma.Wm82.gnm5.ann1.J7HW.gene_models_main.bed.gz
 
 # Protein
 curl -O $url_base/max/annotations/58-161.gnm1.ann1.HJ1K/glyma.58-161.gnm1.ann1.HJ1K.protein_primary.faa.gz

--- a/get_data/get_Glycine_7_3_2.sh
+++ b/get_data/get_Glycine_7_3_2.sh
@@ -67,12 +67,12 @@ for file in *gff3.gz; do
 done
 
 # Patch glyso.W05.gnm1.ann1 annotations: the CDS and protein files have Glysoja.10G027808, but the BED does not.
-zcat glyso.W05.gnm1.ann1.T47J.protein_primary.faa.gz | ../bin/fasta_to_table.awk | awk '$1!~/Glysoja.10G027808/' | 
+zcat glyso.W05.gnm1.ann1.T47J.protein_primary.faa.gz | fasta_to_table.awk | awk '$1!~/Glysoja.10G027808/' | 
   awk -v FS="\t" '{print ">" $1; print $2}' > tmp.prot_primary.faa
   mv tmp.prot_primary.faa glyso.W05.gnm1.ann1.T47J.protein_primary.faa
   gzip -f glyso.W05.gnm1.ann1.T47J.protein_primary.faa
 
-zcat glyso.W05.gnm1.ann1.T47J.cds_primary.fna.gz | ../bin/fasta_to_table.awk | awk '$1!~/Glysoja.10G027808/' |
+zcat glyso.W05.gnm1.ann1.T47J.cds_primary.fna.gz | fasta_to_table.awk | awk '$1!~/Glysoja.10G027808/' |
   awk -v FS="\t" '{print ">" $1; print $2}'  > tmp.cds_primary.fna
   mv tmp.cds_primary.fna glyso.W05.gnm1.ann1.T47J.cds_primary.fna
   gzip -f glyso.W05.gnm1.ann1.T47J.cds_primary.fna

--- a/get_data/get_Glycine_7_3_2.sh
+++ b/get_data/get_Glycine_7_3_2.sh
@@ -17,46 +17,46 @@ base_dir=$PWD
 cd $base_dir/data_pan/
 
 # CDS
-curl -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.cds_primary.fna.gz
-curl -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.cds.fna.gz
-curl -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.cds_primary.fna.gz
-curl -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.cds_primary.fna.gz
-curl -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.cds.fna.gz
-curl -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.cds_primary.fna.gz
-curl -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.cds.fna.gz
+curl -f -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.cds_primary.fna.gz
+curl -f -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.cds.fna.gz
+curl -f -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.cds_primary.fna.gz
+curl -f -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.cds_primary.fna.gz
 # 
 # BED or GFF
-curl -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.gene_models_main.gff3.gz
-curl -O $url_base//max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.gene_models_main.gff3.gz
-curl -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.gene_models_main.gff3.gz
-curl -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.gene_models_main.gff3.gz
-curl -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.gene_models_main.gff3.gz
+curl -f -O $url_base//max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.gene_models_main.gff3.gz
+curl -f -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.gene_models_main.gff3.gz
+curl -f -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.gene_models_main.gff3.gz
+curl -f -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.gene_models_main.gff3.gz
 
 # Protein
-curl -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.protein_primary.faa.gz
-curl -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.protein.faa.gz
-curl -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.protein_primary.faa.gz
-curl -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.protein_primary.faa.gz
-curl -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.protein.faa.gz
-curl -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.protein_primary.faa.gz
-curl -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Lee.gnm1.ann1.6NZV/glyma.Lee.gnm1.ann1.6NZV.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/JD17.gnm1.ann1.CLFP/glyma.JD17.gnm1.ann1.CLFP.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Jinyuan_IGA1006.gnm1.ann1.2NNX/glyma.Jinyuan_IGA1006.gnm1.ann1.2NNX.protein.faa.gz
+curl -f -O $url_base/max/annotations/PI_398296.gnm1.ann1.B0XR/glyma.PI_398296.gnm1.ann1.B0XR.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/PI_548362.gnm1.ann1.LL84/glyma.PI_548362.gnm1.ann1.LL84.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm2.ann1.RVB6/glyma.Wm82.gnm2.ann1.RVB6.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Wm82.gnm1.ann1.DvBy/glyma.Wm82.gnm1.ann1.DvBy.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Zh13.gnm1.ann1.8VV3/glyma.Zh13.gnm1.ann1.8VV3.protein_primary.faa.gz
+curl -f -O $url_base/max/annotations/Zh35_IGA1004.gnm1.ann1.RGN6/glyma.Zh35_IGA1004.gnm1.ann1.RGN6.protein.faa.gz
+curl -f -O $url_base/soja/annotations/PI483463.gnm1.ann1.3Q3Q/glyso.PI483463.gnm1.ann1.3Q3Q.protein_primary.faa.gz
+curl -f -O $url_base/soja/annotations/W05.gnm1.ann1.T47J/glyso.W05.gnm1.ann1.T47J.protein_primary.faa.gz
 
 # Convert from gff3 to bed7
 for file in *gff3.gz; do

--- a/get_data/get_Medicago.sh
+++ b/get_data/get_Medicago.sh
@@ -14,25 +14,25 @@ url_base="https://data.legumeinfo.org/Medicago"
 ## data
 base_dir=$PWD
 cd $base_dir/data
-curl -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.bed.gz
-curl -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed.gz
-curl -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.cds.bed.gz
-curl -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.cds.bed.gz
-curl -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.cds.bed.gz
-curl -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.cds.bed.gz
+curl -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.gene_models_main.bed.gz
+curl -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.gene_models_main.bed.gz
 
 curl -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.fna.gz
 curl -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds_primary.fna.gz
@@ -81,20 +81,22 @@ echo "  Uncompress files"
 for file in *; do gunzip $file & 
 done
 
-echo "  Tweak chromosome names for medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed"
-    perl -pi -e 's/MtrunA17Chr0c/scaff_/' medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed
-    perl -pi -e 's/MtrunA17Chr/chr/; s/MtrunA17CP/CP/; s/MtrunA17MT/MT/' medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed
+wait
+
+echo "  Tweak chromosome names for medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed"
+    perl -pi -e 's/MtrunA17Chr0c/scaff_/' medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed
+    perl -pi -e 's/MtrunA17Chr/chr/; s/MtrunA17CP/CP/; s/MtrunA17MT/MT/' medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed
 
 echo "  For sativa, split it into five files: scaffolds in one, and .1 .2 .3 .4 chromosomes into four others."
-    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.bed | awk '$1!~/chr/' | 
-      perl -pe 's/(medsa.XinJiangDaYe.gnm1).(\d+)/$1.scaff$2/' > medsa.XinJiangDaYe_sc.gnm1.ann1.RKB9.cds.bed
-    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.bed | awk '$1~/chr[1-8].1/' > medsa.XinJiangDaYe_1.gnm1.ann1.RKB9.cds.bed
-    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.bed | awk '$1~/chr[1-8].2/' > medsa.XinJiangDaYe_2.gnm1.ann1.RKB9.cds.bed
-    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.bed | awk '$1~/chr[1-8].3/' > medsa.XinJiangDaYe_3.gnm1.ann1.RKB9.cds.bed
-    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.bed | awk '$1~/chr[1-8].4/' > medsa.XinJiangDaYe_4.gnm1.ann1.RKB9.cds.bed
-    #rm medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.bed
+    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed | awk '$1!~/chr/' | 
+      perl -pe 's/(medsa.XinJiangDaYe.gnm1).(\d+)/$1.scaff$2/' > medsa.XinJiangDaYe_sc.gnm1.ann1.RKB9.gene_models_main.bed
+    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed | awk '$1~/chr[1-8].1/' > medsa.XinJiangDaYe_1.gnm1.ann1.RKB9.gene_models_main.bed
+    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed | awk '$1~/chr[1-8].2/' > medsa.XinJiangDaYe_2.gnm1.ann1.RKB9.gene_models_main.bed
+    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed | awk '$1~/chr[1-8].3/' > medsa.XinJiangDaYe_3.gnm1.ann1.RKB9.gene_models_main.bed
+    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed | awk '$1~/chr[1-8].4/' > medsa.XinJiangDaYe_4.gnm1.ann1.RKB9.gene_models_main.bed
+    #rm medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed
 
-    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.fna | ../bin/fasta_to_table.awk > medsa.XJDY.fna1
+    cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.fna | fasta_to_table.awk > medsa.XJDY.fna1
     cat medsa.XJDY.fna1 | awk '$2!~/chr/ {print ">" $1 " " $2 "\n" $3}' > medsa.XinJiangDaYe_sc.gnm1.ann1.RKB9.cds.fna
     cat medsa.XJDY.fna1 | awk '$2~/chr[1-8].1/ {print ">" $1 " " $2 "\n" $3}' > medsa.XinJiangDaYe_1.gnm1.ann1.RKB9.cds.fna
     cat medsa.XJDY.fna1 | awk '$2~/chr[1-8].2/ {print ">" $1 " " $2 "\n" $3}' > medsa.XinJiangDaYe_2.gnm1.ann1.RKB9.cds.fna
@@ -104,7 +106,7 @@ echo "  For sativa, split it into five files: scaffolds in one, and .1 .2 .3 .4 
     #rm medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.fna
 
     cat medsa.XinJiangDaYe.gnm1.ann1.RKB9.protein.faa | perl -pe 's/ \[translate_table: standard\]//' | 
-      ../bin/fasta_to_table.awk > medsa.XJDY.faa1
+      fasta_to_table.awk > medsa.XJDY.faa1
     cat medsa.XJDY.faa1 | awk '$2!~/chr/ {print ">" $1 " " $2 "\n" $3}' > medsa.XinJiangDaYe_sc.gnm1.ann1.RKB9.protein.faa
     cat medsa.XJDY.faa1 | awk '$2~/chr[1-8].1/ {print ">" $1 " " $2 "\n" $3}' > medsa.XinJiangDaYe_1.gnm1.ann1.RKB9.protein.faa
     cat medsa.XJDY.faa1 | awk '$2~/chr[1-8].2/ {print ">" $1 " " $2 "\n" $3}' > medsa.XinJiangDaYe_2.gnm1.ann1.RKB9.protein.faa
@@ -114,7 +116,7 @@ echo "  For sativa, split it into five files: scaffolds in one, and .1 .2 .3 .4 
     #rm medsa.XinJiangDaYe.gnm1.ann1.RKB9.protein.faa
 
 echo "  Then shorten the chr names from e.g. chr8.1 to chr8, because we want them co-equal (chr1.1 can match chr1.4)"
-    perl -pi -e 's/(chr\d)\.\d/$1/' medsa.XinJiangDaYe_?.gnm1.ann1.RKB9.cds.bed
+    perl -pi -e 's/(chr\d)\.\d/$1/' medsa.XinJiangDaYe_?.gnm1.ann1.RKB9.gene_models_main.bed
 
 echo "  Name the sativa subgenome prefixes in both the chromosome and gene name fields, in all medsa.XinJiangDaYe files"
   perl -pi -e 's/XinJiangDaYe.gnm1/XinJiangDaYe_1.gnm1/g' medsa.XinJiangDaYe_1.gnm1.ann1.*
@@ -127,12 +129,12 @@ echo "  Fix a gene-name discrepancy in medtr.A17_HM341.gnm4.ann2"
     # bed file has gene names like this:    medtr.A17_HM341.gnm4.ann2.mRNA:MtrunA17Chr2g0284411
     # fasta file has gene names like this:  medtr.A17_HM341.gnm4.ann2.MtrunA17_Chr2g0284411
     # Use the latter form, by removing "mRNA:"
-      perl -pi -e 's/mRNA://' medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed
-      perl -pi -e 's/MtrunA17/MtrunA17_/' medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed
-      perl -pi -e 's/chr0c/MtrunA17_Chr0c/' medtr.A17_HM341.gnm4.ann2.G3ZY.cds.bed
+      perl -pi -e 's/mRNA://' medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed
+      perl -pi -e 's/MtrunA17/MtrunA17_/' medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed
+      perl -pi -e 's/chr0c/MtrunA17_Chr0c/' medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed
 
-echo "  Fix funky scaffold names in  medtr.A17.gnm5.ann1_6.L2RX.cds.bed"
-      perl -pi -e 's/MtrunA17Chr0c/scaff_/' medtr.A17.gnm5.ann1_6.L2RX.cds.bed
+echo "  Fix funky scaffold names in  medtr.A17.gnm5.ann1_6.L2RX.gene_models_main.bed"
+      perl -pi -e 's/MtrunA17Chr0c/scaff_/' medtr.A17.gnm5.ann1_6.L2RX.gene_models_main.bed
 
 
 echo "  Check chromosome names. For some of these tests, the results should be empty."
@@ -155,6 +157,8 @@ echo "Check: how many CHROMOSOMES are in each annotation?"
 echo  "  Re-compress the files"
     for file in *bed *fna *.faa ; do gzip $file &
     done
+
+wait
 
 # Skip chromosome correspondences, because most of the assemblies/annotations have no chromosome assignments.
 cat<<DATA >expected_chr_matches.tsv

--- a/get_data/get_Medicago.sh
+++ b/get_data/get_Medicago.sh
@@ -14,65 +14,65 @@ url_base="https://data.legumeinfo.org/Medicago"
 ## data
 base_dir=$PWD
 cd $base_dir/data
-curl -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.gene_models_main.bed.gz
-curl -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.gene_models_main.bed.gz
+curl -f -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.gene_models_main.bed.gz
+curl -f -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.gene_models_main.bed.gz
 
-curl -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.fna.gz
-curl -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds_primary.fna.gz
-curl -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.cds.fna.gz
-curl -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.cds.fna.gz
-curl -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.cds_primary.fna.gz
-curl -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.cds.fna.gz
+curl -f -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds_primary.fna.gz
+curl -f -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.cds.fna.gz
+curl -f -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.cds_primary.fna.gz
+curl -f -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.cds.fna.gz
 
-curl -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.protein.faa.gz
-curl -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.protein_primary.faa.gz
-curl -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.protein.faa.gz
-curl -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.protein.faa.gz
-curl -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.protein_primary.faa.gz
-curl -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.protein.faa.gz
+curl -f -O $url_base/sativa/annotations/XinJiangDaYe.gnm1.ann1.RKB9/medsa.XinJiangDaYe.gnm1.ann1.RKB9.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.protein_primary.faa.gz
+curl -f -O $url_base/truncatula/annotations/A17.gnm5.ann1_6.L2RX/medtr.A17.gnm5.ann1_6.L2RX.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM004.gnm1.ann1.2XTB/medtr.HM004.gnm1.ann1.2XTB.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM010.gnm1.ann1.WV9J/medtr.HM010.gnm1.ann1.WV9J.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM022.gnm1.ann1.6C8N/medtr.HM022.gnm1.ann1.6C8N.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM023.gnm1.ann1.WZN8/medtr.HM023.gnm1.ann1.WZN8.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM034.gnm1.ann1.YR6S/medtr.HM034.gnm1.ann1.YR6S.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM050.gnm1.ann1.GWRX/medtr.HM050.gnm1.ann1.GWRX.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM056.gnm1.ann1.CHP6/medtr.HM056.gnm1.ann1.CHP6.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM058.gnm1.ann1.LXPZ/medtr.HM058.gnm1.ann1.LXPZ.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM060.gnm1.ann1.H41P/medtr.HM060.gnm1.ann1.H41P.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM095.gnm1.ann1.55W4/medtr.HM095.gnm1.ann1.55W4.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM125.gnm1.ann1.KY5W/medtr.HM125.gnm1.ann1.KY5W.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM129.gnm1.ann1.7FTD/medtr.HM129.gnm1.ann1.7FTD.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM185.gnm1.ann1.GB3D/medtr.HM185.gnm1.ann1.GB3D.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/HM324.gnm1.ann1.SQH2/medtr.HM324.gnm1.ann1.SQH2.protein.faa.gz
+curl -f -O $url_base/truncatula/annotations/R108_HM340.gnm1.ann1.85YW/medtr.R108_HM340.gnm1.ann1.85YW.protein_primary.faa.gz
+curl -f -O $url_base/truncatula/annotations/R108.gnmHiC_1.ann1.Y8NH/medtr.R108.gnmHiC_1.ann1.Y8NH.protein.faa.gz
 
 
 echo "Change chromosome names for some of the files, to allow later filtering by chromosome correspondence"

--- a/get_data/get_Phaseolus.sh
+++ b/get_data/get_Phaseolus.sh
@@ -15,32 +15,32 @@ url_base="https://data.legumeinfo.org/Phaseolus"
 ## data
 base_dir=$PWD
 cd $base_dir/data/
-  curl -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.cds_primary.fna.gz
-  curl -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.cds_primary.fna.gz
-  curl -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.cds_primary.fna.gz
-  curl -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.cds_primary.fna.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.cds_primary.fna.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.cds_primary.fna.gz
-  curl -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.cds_primary.fna.gz
-  curl -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.cds_primary.fna.gz
+  curl -f -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.cds_primary.fna.gz
+  curl -f -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.cds_primary.fna.gz
+  curl -f -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.cds_primary.fna.gz
+  curl -f -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.cds_primary.fna.gz
+  curl -f -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.cds_primary.fna.gz
+  curl -f -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.cds_primary.fna.gz
+  curl -f -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.cds_primary.fna.gz
+  curl -f -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.cds_primary.fna.gz
 
-  curl -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.gene_models_main.bed.gz
-  curl -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.gene_models_main.bed.gz
-  curl -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.gene_models_main.bed.gz
-  curl -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.gene_models_main.bed.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.gene_models_main.bed.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.bed.gz
-  curl -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.gene_models_main.bed.gz
-  curl -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.gene_models_main.bed.gz
+  curl -f -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.gene_models_main.bed.gz
+  curl -f -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.gene_models_main.bed.gz
+  curl -f -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.gene_models_main.bed.gz
+  curl -f -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.gene_models_main.bed.gz
+  curl -f -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.gene_models_main.bed.gz
+  curl -f -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.bed.gz
+  curl -f -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.gene_models_main.bed.gz
+  curl -f -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.gene_models_main.bed.gz
 
-  curl -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.protein_primary.faa.gz
-  curl -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.protein_primary.faa.gz
-  curl -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.protein_primary.faa.gz
-  curl -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.protein_primary.faa.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.protein_primary.faa.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.protein_primary.faa.gz
-  curl -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.protein_primary.faa.gz
-  curl -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.protein_primary.faa.gz
+  curl -f -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.protein_primary.faa.gz
+  curl -f -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.protein_primary.faa.gz
+  curl -f -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.protein_primary.faa.gz
+  curl -f -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.protein_primary.faa.gz
+  curl -f -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.protein_primary.faa.gz
+  curl -f -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.protein_primary.faa.gz
+  curl -f -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.protein_primary.faa.gz
+  curl -f -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.protein_primary.faa.gz
 
 
 # Fix the forms of chromosome IDs, if necessary

--- a/get_data/get_Phaseolus.sh
+++ b/get_data/get_Phaseolus.sh
@@ -24,14 +24,14 @@ cd $base_dir/data/
   curl -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.cds_primary.fna.gz
   curl -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.cds_primary.fna.gz
 
-  curl -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.cds.bed.gz
-  curl -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.cds.bed.gz
-  curl -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.cds.bed.gz
-  curl -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.cds.bed.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.cds.bed.gz
-  curl -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.cds.bed.gz
-  curl -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.cds.bed.gz
-  curl -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.cds.bed.gz
+  curl -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.gene_models_main.bed.gz
+  curl -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.gene_models_main.bed.gz
+  curl -O $url_base/lunatus/annotations/G27455.gnm1.ann1.JD7C/phalu.G27455.gnm1.ann1.JD7C.gene_models_main.bed.gz
+  curl -O $url_base/vulgaris/annotations/5-593.gnm1.ann1.3FBJ/phavu.5-593.gnm1.ann1.3FBJ.gene_models_main.bed.gz
+  curl -O $url_base/vulgaris/annotations/G19833.gnm1.ann1.pScz/phavu.G19833.gnm1.ann1.pScz.gene_models_main.bed.gz
+  curl -O $url_base/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.bed.gz
+  curl -O $url_base/vulgaris/annotations/LaborOvalle.gnm1.ann1.L1DY/phavu.LaborOvalle.gnm1.ann1.L1DY.gene_models_main.bed.gz
+  curl -O $url_base/vulgaris/annotations/UI111.gnm1.ann1.8L4N/phavu.UI111.gnm1.ann1.8L4N.gene_models_main.bed.gz
 
   curl -O $url_base/acutifolius/annotations/Frijol_Bayo.gnm1.ann1.ML22/phaac.Frijol_Bayo.gnm1.ann1.ML22.protein_primary.faa.gz
   curl -O $url_base/acutifolius/annotations/W6_15578.gnm2.ann1.LVZ1/phaac.W6_15578.gnm2.ann1.LVZ1.protein_primary.faa.gz

--- a/get_data/get_Vigna.sh
+++ b/get_data/get_Vigna.sh
@@ -15,47 +15,47 @@ url_base="https://data.legumeinfo.org/Vigna"
 ## data
 base_dir=$PWD
 cd $base_dir/data/
-  curl -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.cds_primary.fna.gz
-  curl -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.cds_primary.fna.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.cds.fna.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.cds.fna.gz
-  curl -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.cds_primary.fna.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.cds_primary.fna.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.cds_primary.fna.gz
-  curl -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.cds_primary.fna.gz
-  curl -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.cds_primary.fna.gz
-  curl -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.cds_primary.fna.gz
-  curl -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.cds_primary.fna.gz
-  #curl -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.cds.fna.gz
-  curl -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.cds_primary.fna.gz
+  curl -f -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.cds_primary.fna.gz
+  curl -f -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.cds_primary.fna.gz
+  curl -f -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.cds.fna.gz
+  curl -f -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.cds.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.cds_primary.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.cds_primary.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.cds_primary.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.cds_primary.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.cds_primary.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.cds_primary.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.cds_primary.fna.gz
+  #curl -f -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.cds.fna.gz
+  curl -f -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.cds_primary.fna.gz
 
-  curl -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.protein_primary.faa.gz
-  curl -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.protein_primary.faa.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.protein.faa.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.protein.faa.gz
-  curl -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.protein_primary.faa.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.protein_primary.faa.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.protein_primary.faa.gz
-  curl -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.protein_primary.faa.gz
-  curl -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.protein_primary.faa.gz
-  curl -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.protein_primary.faa.gz
-  curl -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.protein_primary.faa.gz
-  #curl -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.protein.faa.gz
-  curl -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.protein_primary.faa.gz
+  curl -f -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.protein_primary.faa.gz
+  curl -f -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.protein_primary.faa.gz
+  curl -f -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.protein.faa.gz
+  curl -f -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.protein.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.protein_primary.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.protein_primary.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.protein_primary.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.protein_primary.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.protein_primary.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.protein_primary.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.protein_primary.faa.gz
+  #curl -f -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.protein.faa.gz
+  curl -f -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.protein_primary.faa.gz
 
-  curl -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.gene_models_main.bed.gz
-  curl -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.gene_models_main.bed.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.gene_models_main.bed.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.gene_models_main.bed.gz
-  #curl -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.gene_models_main.bed.gz
-  curl -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.gene_models_main.bed.gz
+  curl -f -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.gene_models_main.bed.gz
+  curl -f -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.gene_models_main.bed.gz
+  curl -f -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.gene_models_main.bed.gz
+  curl -f -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.gene_models_main.bed.gz
+  #curl -f -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.gene_models_main.bed.gz
+  curl -f -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.gene_models_main.bed.gz
 
 # Fix the forms of chromosome IDs
   for file in *; do gunzip $file & done

--- a/get_data/get_Vigna.sh
+++ b/get_data/get_Vigna.sh
@@ -43,22 +43,24 @@ cd $base_dir/data/
   #curl -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.protein.faa.gz
   curl -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.protein_primary.faa.gz
 
-  curl -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.cds.bed.gz
-  curl -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.cds.bed.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.cds.bed.gz
-  curl -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.cds.bed.gz
-  #curl -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.cds.bed.gz
-  curl -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.cds.bed.gz
+  curl -O $url_base/angularis/annotations/Gyeongwon.gnm3.ann1.3Nz5/vigan.Gyeongwon.gnm3.ann1.3Nz5.gene_models_main.bed.gz
+  curl -O $url_base/angularis/annotations/Shumari.gnm1.ann1.8BRS/vigan.Shumari.gnm1.ann1.8BRS.gene_models_main.bed.gz
+  curl -O $url_base/radiata/annotations/VC1973A.gnm6.ann1.M1Qs/vigra.VC1973A.gnm6.ann1.M1Qs.gene_models_main.bed.gz
+  curl -O $url_base/radiata/annotations/VC1973A.gnm7.ann1.RWBG/vigra.VC1973A.gnm7.ann1.RWBG.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/CB5-2.gnm1.ann1.0GKC/vigun.CB5-2.gnm1.ann1.0GKC.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann1.zb5D/vigun.IT97K-499-35.gnm1.ann1.zb5D.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/Sanzi.gnm1.ann1.HFH8/vigun.Sanzi.gnm1.ann1.HFH8.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/Suvita2.gnm1.ann1.1PF6/vigun.Suvita2.gnm1.ann1.1PF6.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/TZ30.gnm1.ann2.59NL/vigun.TZ30.gnm1.ann2.59NL.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/UCR779.gnm1.ann1.VF6G/vigun.UCR779.gnm1.ann1.VF6G.gene_models_main.bed.gz
+  #curl -O $url_base/unguiculata/annotations/Xiabao_II.gnm1.ann1.4JFL/vigun.Xiabao_II.gnm1.ann1.4JFL.gene_models_main.bed.gz
+  curl -O $url_base/unguiculata/annotations/ZN016.gnm1.ann2.C7YV/vigun.ZN016.gnm1.ann2.C7YV.gene_models_main.bed.gz
 
 # Fix the forms of chromosome IDs
   for file in *; do gunzip $file & done
+
+wait
 
   perl -pi -e 's/vigan.Gyeongwon.gnm3.Va(\d+)/vigan.Gyeongwon.gnm3.chr$1/' vigan.Gyeongwon.gnm3*.bed &
   perl -pi -e 's/vigan.Shumari.gnm1.Chr(\d+)/vigan.Shumari.gnm1.chr$1/' vigan.Shumari.gnm1*.bed &
@@ -74,6 +76,8 @@ cd $base_dir/data/
   #perl -pi -e 's/vigun.Xiabao_II.gnm1.LG(\d\d)\t/vigun.Xiabao_II.gnm1.chr$1\t/' vigun.Xiabao_II.gnm1*.bed &
   perl -pi -e 's/vigun.ZN016.gnm1.chr(\d)\t/vigun.ZN016.gnm1.chr0$1\t/' vigun.ZN016.gnm1*.bed &
 
+wait
+
 # Check chromosome names
   for file in *bed; do cat $file | awk '$1~/chr/ {print $1}' | sort | uniq -c ; echo; done
 
@@ -82,6 +86,8 @@ cd $base_dir/data/
 # Re-compress the files
   for file in *bed *fna *faa; do gzip $file &
   done
+
+wait
 
 cat <<DATA > expected_chr_matches.tsv
 # Expected chromosome matches for Vigna unguiculata

--- a/get_data/get_Zea.sh
+++ b/get_data/get_Zea.sh
@@ -15,96 +15,96 @@ base_dir=$PWD
 url_base="https://download.maizegdb.org"
 
 cd data_orig
-curl -O $url_base/Zm-B73-REFERENCE-GRAMENE-4.0/Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.cds.fa.gz
-curl -O $url_base/Zm-B73-REFERENCE-NAM-5.0/Zm-B73-REFERENCE-NAM-5.0_Zm00001eb.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-B97-REFERENCE-NAM-1.0/Zm-B97-REFERENCE-NAM-1.0_Zm00018ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML103-REFERENCE-NAM-1.0/Zm-CML103-REFERENCE-NAM-1.0_Zm00021ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML228-REFERENCE-NAM-1.0/Zm-CML228-REFERENCE-NAM-1.0_Zm00022ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML247-REFERENCE-NAM-1.0/Zm-CML247-REFERENCE-NAM-1.0_Zm00023ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML277-REFERENCE-NAM-1.0/Zm-CML277-REFERENCE-NAM-1.0_Zm00024ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML322-REFERENCE-NAM-1.0/Zm-CML322-REFERENCE-NAM-1.0_Zm00025ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML333-REFERENCE-NAM-1.0/Zm-CML333-REFERENCE-NAM-1.0_Zm00026ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML52-REFERENCE-NAM-1.0/Zm-CML52-REFERENCE-NAM-1.0_Zm00019ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-CML69-REFERENCE-NAM-1.0/Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.cds.fa.gz
-curl -O $url_base/Zm-HP301-REFERENCE-NAM-1.0/Zm-HP301-REFERENCE-NAM-1.0_Zm00027ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Il14H-REFERENCE-NAM-1.0/Zm-Il14H-REFERENCE-NAM-1.0_Zm00028ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Ki11-REFERENCE-NAM-1.0/Zm-Ki11-REFERENCE-NAM-1.0_Zm00030ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Ki3-REFERENCE-NAM-1.0/Zm-Ki3-REFERENCE-NAM-1.0_Zm00029ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Ky21-REFERENCE-NAM-1.0/Zm-Ky21-REFERENCE-NAM-1.0_Zm00031ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-M162W-REFERENCE-NAM-1.0/Zm-M162W-REFERENCE-NAM-1.0_Zm00033ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-M37W-REFERENCE-NAM-1.0/Zm-M37W-REFERENCE-NAM-1.0_Zm00032ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Mo18W-REFERENCE-NAM-1.0/Zm-Mo18W-REFERENCE-NAM-1.0_Zm00034ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Ms71-REFERENCE-NAM-1.0/Zm-Ms71-REFERENCE-NAM-1.0_Zm00035ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-NC350-REFERENCE-NAM-1.0/Zm-NC350-REFERENCE-NAM-1.0_Zm00036ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-NC358-REFERENCE-NAM-1.0/Zm-NC358-REFERENCE-NAM-1.0_Zm00037ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Oh43-REFERENCE-NAM-1.0/Zm-Oh43-REFERENCE-NAM-1.0_Zm00039ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Oh7B-REFERENCE-NAM-1.0/Zm-Oh7B-REFERENCE-NAM-1.0_Zm00038ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-P39-REFERENCE-NAM-1.0/Zm-P39-REFERENCE-NAM-1.0_Zm00040ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.cds.fa.gz
-curl -O $url_base/Zm-Tx303-REFERENCE-NAM-1.0/Zm-Tx303-REFERENCE-NAM-1.0_Zm00041ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-Tzi8-REFERENCE-NAM-1.0/Zm-Tzi8-REFERENCE-NAM-1.0_Zm00042ab.1.canonical.cds.fa.gz
-curl -O $url_base/Zm-W22-REFERENCE-NRGENE-2.0/Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.cds.fa.gz
+curl -f -O $url_base/Zm-B73-REFERENCE-GRAMENE-4.0/Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.cds.fa.gz
+curl -f -O $url_base/Zm-B73-REFERENCE-NAM-5.0/Zm-B73-REFERENCE-NAM-5.0_Zm00001eb.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-B97-REFERENCE-NAM-1.0/Zm-B97-REFERENCE-NAM-1.0_Zm00018ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML103-REFERENCE-NAM-1.0/Zm-CML103-REFERENCE-NAM-1.0_Zm00021ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML228-REFERENCE-NAM-1.0/Zm-CML228-REFERENCE-NAM-1.0_Zm00022ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML247-REFERENCE-NAM-1.0/Zm-CML247-REFERENCE-NAM-1.0_Zm00023ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML277-REFERENCE-NAM-1.0/Zm-CML277-REFERENCE-NAM-1.0_Zm00024ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML322-REFERENCE-NAM-1.0/Zm-CML322-REFERENCE-NAM-1.0_Zm00025ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML333-REFERENCE-NAM-1.0/Zm-CML333-REFERENCE-NAM-1.0_Zm00026ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML52-REFERENCE-NAM-1.0/Zm-CML52-REFERENCE-NAM-1.0_Zm00019ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-CML69-REFERENCE-NAM-1.0/Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.cds.fa.gz
+curl -f -O $url_base/Zm-HP301-REFERENCE-NAM-1.0/Zm-HP301-REFERENCE-NAM-1.0_Zm00027ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Il14H-REFERENCE-NAM-1.0/Zm-Il14H-REFERENCE-NAM-1.0_Zm00028ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Ki11-REFERENCE-NAM-1.0/Zm-Ki11-REFERENCE-NAM-1.0_Zm00030ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Ki3-REFERENCE-NAM-1.0/Zm-Ki3-REFERENCE-NAM-1.0_Zm00029ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Ky21-REFERENCE-NAM-1.0/Zm-Ky21-REFERENCE-NAM-1.0_Zm00031ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-M162W-REFERENCE-NAM-1.0/Zm-M162W-REFERENCE-NAM-1.0_Zm00033ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-M37W-REFERENCE-NAM-1.0/Zm-M37W-REFERENCE-NAM-1.0_Zm00032ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Mo18W-REFERENCE-NAM-1.0/Zm-Mo18W-REFERENCE-NAM-1.0_Zm00034ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Ms71-REFERENCE-NAM-1.0/Zm-Ms71-REFERENCE-NAM-1.0_Zm00035ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-NC350-REFERENCE-NAM-1.0/Zm-NC350-REFERENCE-NAM-1.0_Zm00036ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-NC358-REFERENCE-NAM-1.0/Zm-NC358-REFERENCE-NAM-1.0_Zm00037ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Oh43-REFERENCE-NAM-1.0/Zm-Oh43-REFERENCE-NAM-1.0_Zm00039ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Oh7B-REFERENCE-NAM-1.0/Zm-Oh7B-REFERENCE-NAM-1.0_Zm00038ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-P39-REFERENCE-NAM-1.0/Zm-P39-REFERENCE-NAM-1.0_Zm00040ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.cds.fa.gz
+curl -f -O $url_base/Zm-Tx303-REFERENCE-NAM-1.0/Zm-Tx303-REFERENCE-NAM-1.0_Zm00041ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-Tzi8-REFERENCE-NAM-1.0/Zm-Tzi8-REFERENCE-NAM-1.0_Zm00042ab.1.canonical.cds.fa.gz
+curl -f -O $url_base/Zm-W22-REFERENCE-NRGENE-2.0/Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.cds.fa.gz
 
-curl -O $url_base/Zm-B73-REFERENCE-GRAMENE-4.0/Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.protein.fa.gz
-curl -O $url_base/Zm-B73-REFERENCE-NAM-5.0/Zm-B73-REFERENCE-NAM-5.0_Zm00001eb.1.protein.fa.gz
-curl -O $url_base/Zm-B97-REFERENCE-NAM-1.0/Zm-B97-REFERENCE-NAM-1.0_Zm00018ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML103-REFERENCE-NAM-1.0/Zm-CML103-REFERENCE-NAM-1.0_Zm00021ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML228-REFERENCE-NAM-1.0/Zm-CML228-REFERENCE-NAM-1.0_Zm00022ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML247-REFERENCE-NAM-1.0/Zm-CML247-REFERENCE-NAM-1.0_Zm00023ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML277-REFERENCE-NAM-1.0/Zm-CML277-REFERENCE-NAM-1.0_Zm00024ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML322-REFERENCE-NAM-1.0/Zm-CML322-REFERENCE-NAM-1.0_Zm00025ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML333-REFERENCE-NAM-1.0/Zm-CML333-REFERENCE-NAM-1.0_Zm00026ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML52-REFERENCE-NAM-1.0/Zm-CML52-REFERENCE-NAM-1.0_Zm00019ab.1.protein.fa.gz
-curl -O $url_base/Zm-CML69-REFERENCE-NAM-1.0/Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.protein.fa.gz
-curl -O $url_base/Zm-HP301-REFERENCE-NAM-1.0/Zm-HP301-REFERENCE-NAM-1.0_Zm00027ab.1.protein.fa.gz
-curl -O $url_base/Zm-Il14H-REFERENCE-NAM-1.0/Zm-Il14H-REFERENCE-NAM-1.0_Zm00028ab.1.protein.fa.gz
-curl -O $url_base/Zm-Ki11-REFERENCE-NAM-1.0/Zm-Ki11-REFERENCE-NAM-1.0_Zm00030ab.1.protein.fa.gz
-curl -O $url_base/Zm-Ki3-REFERENCE-NAM-1.0/Zm-Ki3-REFERENCE-NAM-1.0_Zm00029ab.1.protein.fa.gz
-curl -O $url_base/Zm-Ky21-REFERENCE-NAM-1.0/Zm-Ky21-REFERENCE-NAM-1.0_Zm00031ab.1.protein.fa.gz
-curl -O $url_base/Zm-M162W-REFERENCE-NAM-1.0/Zm-M162W-REFERENCE-NAM-1.0_Zm00033ab.1.protein.fa.gz
-curl -O $url_base/Zm-M37W-REFERENCE-NAM-1.0/Zm-M37W-REFERENCE-NAM-1.0_Zm00032ab.1.protein.fa.gz
-curl -O $url_base/Zm-Mo18W-REFERENCE-NAM-1.0/Zm-Mo18W-REFERENCE-NAM-1.0_Zm00034ab.1.protein.fa.gz
-curl -O $url_base/Zm-Ms71-REFERENCE-NAM-1.0/Zm-Ms71-REFERENCE-NAM-1.0_Zm00035ab.1.protein.fa.gz
-curl -O $url_base/Zm-NC350-REFERENCE-NAM-1.0/Zm-NC350-REFERENCE-NAM-1.0_Zm00036ab.1.protein.fa.gz
-curl -O $url_base/Zm-NC358-REFERENCE-NAM-1.0/Zm-NC358-REFERENCE-NAM-1.0_Zm00037ab.1.protein.fa.gz
-curl -O $url_base/Zm-Oh43-REFERENCE-NAM-1.0/Zm-Oh43-REFERENCE-NAM-1.0_Zm00039ab.1.protein.fa.gz
-curl -O $url_base/Zm-Oh7B-REFERENCE-NAM-1.0/Zm-Oh7B-REFERENCE-NAM-1.0_Zm00038ab.1.protein.fa.gz
-curl -O $url_base/Zm-P39-REFERENCE-NAM-1.0/Zm-P39-REFERENCE-NAM-1.0_Zm00040ab.1.protein.fa.gz
-curl -O $url_base/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.protein.fa.gz
-curl -O $url_base/Zm-Tx303-REFERENCE-NAM-1.0/Zm-Tx303-REFERENCE-NAM-1.0_Zm00041ab.1.protein.fa.gz
-curl -O $url_base/Zm-Tzi8-REFERENCE-NAM-1.0/Zm-Tzi8-REFERENCE-NAM-1.0_Zm00042ab.1.protein.fa.gz
-curl -O $url_base/Zm-W22-REFERENCE-NRGENE-2.0/Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.protein.fa.gz
+curl -f -O $url_base/Zm-B73-REFERENCE-GRAMENE-4.0/Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.protein.fa.gz
+curl -f -O $url_base/Zm-B73-REFERENCE-NAM-5.0/Zm-B73-REFERENCE-NAM-5.0_Zm00001eb.1.protein.fa.gz
+curl -f -O $url_base/Zm-B97-REFERENCE-NAM-1.0/Zm-B97-REFERENCE-NAM-1.0_Zm00018ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML103-REFERENCE-NAM-1.0/Zm-CML103-REFERENCE-NAM-1.0_Zm00021ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML228-REFERENCE-NAM-1.0/Zm-CML228-REFERENCE-NAM-1.0_Zm00022ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML247-REFERENCE-NAM-1.0/Zm-CML247-REFERENCE-NAM-1.0_Zm00023ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML277-REFERENCE-NAM-1.0/Zm-CML277-REFERENCE-NAM-1.0_Zm00024ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML322-REFERENCE-NAM-1.0/Zm-CML322-REFERENCE-NAM-1.0_Zm00025ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML333-REFERENCE-NAM-1.0/Zm-CML333-REFERENCE-NAM-1.0_Zm00026ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML52-REFERENCE-NAM-1.0/Zm-CML52-REFERENCE-NAM-1.0_Zm00019ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-CML69-REFERENCE-NAM-1.0/Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-HP301-REFERENCE-NAM-1.0/Zm-HP301-REFERENCE-NAM-1.0_Zm00027ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Il14H-REFERENCE-NAM-1.0/Zm-Il14H-REFERENCE-NAM-1.0_Zm00028ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Ki11-REFERENCE-NAM-1.0/Zm-Ki11-REFERENCE-NAM-1.0_Zm00030ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Ki3-REFERENCE-NAM-1.0/Zm-Ki3-REFERENCE-NAM-1.0_Zm00029ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Ky21-REFERENCE-NAM-1.0/Zm-Ky21-REFERENCE-NAM-1.0_Zm00031ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-M162W-REFERENCE-NAM-1.0/Zm-M162W-REFERENCE-NAM-1.0_Zm00033ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-M37W-REFERENCE-NAM-1.0/Zm-M37W-REFERENCE-NAM-1.0_Zm00032ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Mo18W-REFERENCE-NAM-1.0/Zm-Mo18W-REFERENCE-NAM-1.0_Zm00034ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Ms71-REFERENCE-NAM-1.0/Zm-Ms71-REFERENCE-NAM-1.0_Zm00035ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-NC350-REFERENCE-NAM-1.0/Zm-NC350-REFERENCE-NAM-1.0_Zm00036ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-NC358-REFERENCE-NAM-1.0/Zm-NC358-REFERENCE-NAM-1.0_Zm00037ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Oh43-REFERENCE-NAM-1.0/Zm-Oh43-REFERENCE-NAM-1.0_Zm00039ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Oh7B-REFERENCE-NAM-1.0/Zm-Oh7B-REFERENCE-NAM-1.0_Zm00038ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-P39-REFERENCE-NAM-1.0/Zm-P39-REFERENCE-NAM-1.0_Zm00040ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.protein.fa.gz
+curl -f -O $url_base/Zm-Tx303-REFERENCE-NAM-1.0/Zm-Tx303-REFERENCE-NAM-1.0_Zm00041ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-Tzi8-REFERENCE-NAM-1.0/Zm-Tzi8-REFERENCE-NAM-1.0_Zm00042ab.1.protein.fa.gz
+curl -f -O $url_base/Zm-W22-REFERENCE-NRGENE-2.0/Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.protein.fa.gz
 
 
-curl -O $url_base/Zm-B73-REFERENCE-GRAMENE-4.0/Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.gff3.gz
-curl -O $url_base/Zm-B73-REFERENCE-NAM-5.0/Zm-B73-REFERENCE-NAM-5.0_Zm00001eb.1.gff3.gz
-curl -O $url_base/Zm-B97-REFERENCE-NAM-1.0/Zm-B97-REFERENCE-NAM-1.0_Zm00018ab.1.gff3.gz
-curl -O $url_base/Zm-CML103-REFERENCE-NAM-1.0/Zm-CML103-REFERENCE-NAM-1.0_Zm00021ab.1.gff3.gz
-curl -O $url_base/Zm-CML228-REFERENCE-NAM-1.0/Zm-CML228-REFERENCE-NAM-1.0_Zm00022ab.1.gff3.gz
-curl -O $url_base/Zm-CML247-REFERENCE-NAM-1.0/Zm-CML247-REFERENCE-NAM-1.0_Zm00023ab.1.gff3.gz
-curl -O $url_base/Zm-CML277-REFERENCE-NAM-1.0/Zm-CML277-REFERENCE-NAM-1.0_Zm00024ab.1.gff3.gz
-curl -O $url_base/Zm-CML322-REFERENCE-NAM-1.0/Zm-CML322-REFERENCE-NAM-1.0_Zm00025ab.1.gff3.gz
-curl -O $url_base/Zm-CML333-REFERENCE-NAM-1.0/Zm-CML333-REFERENCE-NAM-1.0_Zm00026ab.1.gff3.gz
-curl -O $url_base/Zm-CML52-REFERENCE-NAM-1.0/Zm-CML52-REFERENCE-NAM-1.0_Zm00019ab.1.gff3.gz
-curl -O $url_base/Zm-CML69-REFERENCE-NAM-1.0/Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.gff3.gz
-curl -O $url_base/Zm-HP301-REFERENCE-NAM-1.0/Zm-HP301-REFERENCE-NAM-1.0_Zm00027ab.1.gff3.gz
-curl -O $url_base/Zm-Il14H-REFERENCE-NAM-1.0/Zm-Il14H-REFERENCE-NAM-1.0_Zm00028ab.1.gff3.gz
-curl -O $url_base/Zm-Ki11-REFERENCE-NAM-1.0/Zm-Ki11-REFERENCE-NAM-1.0_Zm00030ab.1.gff3.gz
-curl -O $url_base/Zm-Ki3-REFERENCE-NAM-1.0/Zm-Ki3-REFERENCE-NAM-1.0_Zm00029ab.1.gff3.gz
-curl -O $url_base/Zm-Ky21-REFERENCE-NAM-1.0/Zm-Ky21-REFERENCE-NAM-1.0_Zm00031ab.1.gff3.gz
-curl -O $url_base/Zm-M162W-REFERENCE-NAM-1.0/Zm-M162W-REFERENCE-NAM-1.0_Zm00033ab.1.gff3.gz
-curl -O $url_base/Zm-M37W-REFERENCE-NAM-1.0/Zm-M37W-REFERENCE-NAM-1.0_Zm00032ab.1.gff3.gz
-curl -O $url_base/Zm-Mo18W-REFERENCE-NAM-1.0/Zm-Mo18W-REFERENCE-NAM-1.0_Zm00034ab.1.gff3.gz
-curl -O $url_base/Zm-Ms71-REFERENCE-NAM-1.0/Zm-Ms71-REFERENCE-NAM-1.0_Zm00035ab.1.gff3.gz
-curl -O $url_base/Zm-NC350-REFERENCE-NAM-1.0/Zm-NC350-REFERENCE-NAM-1.0_Zm00036ab.1.gff3.gz
-curl -O $url_base/Zm-NC358-REFERENCE-NAM-1.0/Zm-NC358-REFERENCE-NAM-1.0_Zm00037ab.1.gff3.gz
-curl -O $url_base/Zm-Oh43-REFERENCE-NAM-1.0/Zm-Oh43-REFERENCE-NAM-1.0_Zm00039ab.1.gff3.gz
-curl -O $url_base/Zm-Oh7B-REFERENCE-NAM-1.0/Zm-Oh7B-REFERENCE-NAM-1.0_Zm00038ab.1.gff3.gz
-curl -O $url_base/Zm-P39-REFERENCE-NAM-1.0/Zm-P39-REFERENCE-NAM-1.0_Zm00040ab.1.gff3.gz
-curl -O $url_base/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.gff3.gz
-curl -O $url_base/Zm-Tx303-REFERENCE-NAM-1.0/Zm-Tx303-REFERENCE-NAM-1.0_Zm00041ab.1.gff3.gz
-curl -O $url_base/Zm-Tzi8-REFERENCE-NAM-1.0/Zm-Tzi8-REFERENCE-NAM-1.0_Zm00042ab.1.gff3.gz
-curl -O $url_base/Zm-W22-REFERENCE-NRGENE-2.0/Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.gff3.gz
+curl -f -O $url_base/Zm-B73-REFERENCE-GRAMENE-4.0/Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.gff3.gz
+curl -f -O $url_base/Zm-B73-REFERENCE-NAM-5.0/Zm-B73-REFERENCE-NAM-5.0_Zm00001eb.1.gff3.gz
+curl -f -O $url_base/Zm-B97-REFERENCE-NAM-1.0/Zm-B97-REFERENCE-NAM-1.0_Zm00018ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML103-REFERENCE-NAM-1.0/Zm-CML103-REFERENCE-NAM-1.0_Zm00021ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML228-REFERENCE-NAM-1.0/Zm-CML228-REFERENCE-NAM-1.0_Zm00022ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML247-REFERENCE-NAM-1.0/Zm-CML247-REFERENCE-NAM-1.0_Zm00023ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML277-REFERENCE-NAM-1.0/Zm-CML277-REFERENCE-NAM-1.0_Zm00024ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML322-REFERENCE-NAM-1.0/Zm-CML322-REFERENCE-NAM-1.0_Zm00025ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML333-REFERENCE-NAM-1.0/Zm-CML333-REFERENCE-NAM-1.0_Zm00026ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML52-REFERENCE-NAM-1.0/Zm-CML52-REFERENCE-NAM-1.0_Zm00019ab.1.gff3.gz
+curl -f -O $url_base/Zm-CML69-REFERENCE-NAM-1.0/Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.gff3.gz
+curl -f -O $url_base/Zm-HP301-REFERENCE-NAM-1.0/Zm-HP301-REFERENCE-NAM-1.0_Zm00027ab.1.gff3.gz
+curl -f -O $url_base/Zm-Il14H-REFERENCE-NAM-1.0/Zm-Il14H-REFERENCE-NAM-1.0_Zm00028ab.1.gff3.gz
+curl -f -O $url_base/Zm-Ki11-REFERENCE-NAM-1.0/Zm-Ki11-REFERENCE-NAM-1.0_Zm00030ab.1.gff3.gz
+curl -f -O $url_base/Zm-Ki3-REFERENCE-NAM-1.0/Zm-Ki3-REFERENCE-NAM-1.0_Zm00029ab.1.gff3.gz
+curl -f -O $url_base/Zm-Ky21-REFERENCE-NAM-1.0/Zm-Ky21-REFERENCE-NAM-1.0_Zm00031ab.1.gff3.gz
+curl -f -O $url_base/Zm-M162W-REFERENCE-NAM-1.0/Zm-M162W-REFERENCE-NAM-1.0_Zm00033ab.1.gff3.gz
+curl -f -O $url_base/Zm-M37W-REFERENCE-NAM-1.0/Zm-M37W-REFERENCE-NAM-1.0_Zm00032ab.1.gff3.gz
+curl -f -O $url_base/Zm-Mo18W-REFERENCE-NAM-1.0/Zm-Mo18W-REFERENCE-NAM-1.0_Zm00034ab.1.gff3.gz
+curl -f -O $url_base/Zm-Ms71-REFERENCE-NAM-1.0/Zm-Ms71-REFERENCE-NAM-1.0_Zm00035ab.1.gff3.gz
+curl -f -O $url_base/Zm-NC350-REFERENCE-NAM-1.0/Zm-NC350-REFERENCE-NAM-1.0_Zm00036ab.1.gff3.gz
+curl -f -O $url_base/Zm-NC358-REFERENCE-NAM-1.0/Zm-NC358-REFERENCE-NAM-1.0_Zm00037ab.1.gff3.gz
+curl -f -O $url_base/Zm-Oh43-REFERENCE-NAM-1.0/Zm-Oh43-REFERENCE-NAM-1.0_Zm00039ab.1.gff3.gz
+curl -f -O $url_base/Zm-Oh7B-REFERENCE-NAM-1.0/Zm-Oh7B-REFERENCE-NAM-1.0_Zm00038ab.1.gff3.gz
+curl -f -O $url_base/Zm-P39-REFERENCE-NAM-1.0/Zm-P39-REFERENCE-NAM-1.0_Zm00040ab.1.gff3.gz
+curl -f -O $url_base/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.gff3.gz
+curl -f -O $url_base/Zm-Tx303-REFERENCE-NAM-1.0/Zm-Tx303-REFERENCE-NAM-1.0_Zm00041ab.1.gff3.gz
+curl -f -O $url_base/Zm-Tzi8-REFERENCE-NAM-1.0/Zm-Tzi8-REFERENCE-NAM-1.0_Zm00042ab.1.gff3.gz
+curl -f -O $url_base/Zm-W22-REFERENCE-NRGENE-2.0/Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.gff3.gz
 
 
 echo "Pick longest CDS for several annotation sets, and exclude provisional"

--- a/get_data/get_Zea.sh
+++ b/get_data/get_Zea.sh
@@ -109,29 +109,29 @@ curl -O $url_base/Zm-W22-REFERENCE-NRGENE-2.0/Zm-W22-REFERENCE-NRGENE-2.0_Zm0000
 
 echo "Pick longest CDS for several annotation sets, and exclude provisional"
 echo "  For GRAMENE-4.0_Zm00001d, also remove 178 GRMZM5 gene models"
-  zcat Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.cds.fa.gz | ../bin/fasta_to_table.awk |
+  zcat Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.cds.fa.gz | fasta_to_table.awk |
     grep -v GRMZM5 |
     perl -pe 's/_T(\d+) ?/\tT$1\t/' |
     awk -v FS="\t" -v OFS="\t" '$0!~/provisional/ {print $1, length($4), $2, $3, $4}' |
-    sort -k1,1 -k2nr,2nr | ../bin/top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
+    sort -k1,1 -k2nr,2nr | top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
     cat | gzip -c  > ../data/Zm-B73-REFERENCE-GRAMENE-4.0_Zm00001d.2.canonical.cds.fa.gz
 
-  zcat Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.cds.fa.gz | ../bin/fasta_to_table.awk |
+  zcat Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.cds.fa.gz | fasta_to_table.awk |
     perl -pe 's/_T(\d+) ?/\tT$1\t/' |
     awk -v FS="\t" -v OFS="\t" '$0!~/provisional/ {print $1, length($4), $2, $3, $4}' |
-    sort -k1,1 -k2nr,2nr | ../bin/top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
+    sort -k1,1 -k2nr,2nr | top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
     cat | gzip -c  > ../data/Zm-W22-REFERENCE-NRGENE-2.0_Zm00004b.1.canonical.cds.fa.gz
 
-  zcat Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.cds.fa.gz | ../bin/fasta_to_table.awk |
+  zcat Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.cds.fa.gz | fasta_to_table.awk |
     perl -pe 's/_T(\d+) ?/\tT$1\t/' |
     awk -v FS="\t" -v OFS="\t" '$0!~/provisional/ {print $1, length($4), $2, $3, $4}' |
-    sort -k1,1 -k2nr,2nr | ../bin/top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
+    sort -k1,1 -k2nr,2nr | top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
     cat | gzip -c  > ../data/Zm-CML69-REFERENCE-NAM-1.0_Zm00020ab.1.canonical.cds.fa.gz
 
-  zcat Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.cds.fa.gz | ../bin/fasta_to_table.awk |
+  zcat Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.cds.fa.gz | fasta_to_table.awk |
     perl -pe 's/_T(\d+) ?/\tT$1\t/' |
     awk -v FS="\t" -v OFS="\t" '$0!~/provisional/ {print $1, length($4), $2, $3, $4}' |
-    sort -k1,1 -k2nr,2nr | ../bin/top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
+    sort -k1,1 -k2nr,2nr | top_line.awk | awk -v FS="\t" '{print ">" $1 "_" $3 " " $4; print $5}' |
     cat | gzip -c > ../data/Zm-PH207-REFERENCE_NS-UIUC_UMN-1.0_Zm00008a.1.canonical.cds.fa.gz
 
 echo "Copy existing canonical cds files from data_orig/ to data/"
@@ -143,9 +143,9 @@ echo "Pick longest proteins for several annotation sets. In the process, convert
   for file in *protein.fa.gz; do 
     base=`basename $file .protein.fa.gz`
     echo "  Copying protein file $base, with ID modification"
-    zcat $file |  perl -pe 's/>(\S+)_P(\d+)/>$1_T$2/' | ../bin/fasta_to_table.awk |
+    zcat $file |  perl -pe 's/>(\S+)_P(\d+)/>$1_T$2/' | fasta_to_table.awk |
     awk -v FS="\t" -v OFS="\t" '$1!~/GRMZM5/ && $1!~/provisional/ {print $1, length($2), $2}' |
-    sort -k1,1 -k2nr,2nr | ../bin/top_line.awk | awk -v FS="\t" '{print ">" $1; print $3}' |
+    sort -k1,1 -k2nr,2nr | top_line.awk | awk -v FS="\t" '{print ">" $1; print $3}' |
     cat | gzip -c > ../data/$base.canonical.protein.fa.gz
   done
 
@@ -155,7 +155,7 @@ echo "Add annotation name (e.g. Zm-W22_NRGENE-2) as prefix to the chromosome/sca
     base=`basename $path .gz`
     echo $base
     export annot_name=$(echo $base | perl -pe 's/(.+)-REFERENCE[-_](.+\d)\.\d_Z\w\d+.+/$1_$2/')
-    zcat $path | ../bin/gff_to_bed7_mRNA.awk | 
+    zcat $path | gff_to_bed7_mRNA.awk | 
       perl -pe '$prefix=$ENV{'annot_name'}; s/^(\D+)/$prefix.$1/; s/transcript://' |
        cat | gzip -c > ../data/$base.bed.gz &
   done
@@ -168,12 +168,7 @@ echo "Change chromosome strings in Zm-B73-REFERENCE-GRAMENE-4.0"
   rm tmp.bed
 
 echo "Re-compress files"
-  for file in *.fa *.gff3; do
-    gzip $file &
-  done
-  wait
-
-  for file in ../data/*fa ../data/*bed; do
+  for file in *.gff3; do
     gzip $file &
   done
   wait

--- a/get_data/get_family_18_3.sh
+++ b/get_data/get_family_18_3.sh
@@ -16,83 +16,83 @@ url_base="https://data.legumeinfo.org"
 base_dir=$PWD
 cd $base_dir/data/
 
-curl -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.cds_primary.fna.gz
-curl -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.gene_models_main.bed.gz
-curl -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.protein_primary.faa.gz
+curl -f -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.cds_primary.fna.gz
+curl -f -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.gene_models_main.bed.gz
+curl -f -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.protein_primary.faa.gz
 
-curl -O $url_base/Arachis/GENUS/pangenes/Arachis.pan2.5P1K/Arachis.pan2.5P1K.pctl40_named_protein.faa.gz
-curl -O $url_base/Arachis/GENUS/pangenes/Arachis.pan2.5P1K/Arachis.pan2.5P1K.pctl40_named_cds.fna.gz
+curl -f -O $url_base/Arachis/GENUS/pangenes/Arachis.pan2.5P1K/Arachis.pan2.5P1K.pctl40_named_protein.faa.gz
+curl -f -O $url_base/Arachis/GENUS/pangenes/Arachis.pan2.5P1K/Arachis.pan2.5P1K.pctl40_named_cds.fna.gz
 
-curl -O $url_base/Cicer/GENUS/pangenes/Cicer.pan2.CMWZ/Cicer.pan2.CMWZ.pctl25_named_protein.faa.gz
-curl -O $url_base/Cicer/GENUS/pangenes/Cicer.pan2.CMWZ/Cicer.pan2.CMWZ.pctl25_named_cds.fna.gz
+curl -f -O $url_base/Cicer/GENUS/pangenes/Cicer.pan2.CMWZ/Cicer.pan2.CMWZ.pctl25_named_protein.faa.gz
+curl -f -O $url_base/Cicer/GENUS/pangenes/Cicer.pan2.CMWZ/Cicer.pan2.CMWZ.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.bed.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.cds.fna.gz
-curl -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.protein.faa.gz
-curl -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.cds.fna.gz
+curl -f -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.protein.faa.gz
+curl -f -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.gene_models_main.bed.gz
 
-curl -O $url_base/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.pctl25_named_protein.faa.gz
-curl -O $url_base/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.pctl25_named_cds.fna.gz
+curl -f -O $url_base/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.pctl25_named_protein.faa.gz
+curl -f -O $url_base/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.gene_models_main.bed.gz
-curl -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.cds.fna.gz
-curl -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.protein.faa.gz
+curl -f -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.gene_models_main.bed.gz
+curl -f -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.cds.fna.gz
+curl -f -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.protein.faa.gz
 
-curl -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.gene_models_main.bed.gz
-curl -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.cds_primary.fna.gz
-curl -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.protein_primary.faa.gz
+curl -f -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.gene_models_main.bed.gz
+curl -f -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.cds_primary.fna.gz
+curl -f -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.protein_primary.faa.gz
 
-curl -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.gene_models_main.bed.gz
-curl -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.cds.fna.gz
-curl -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.protein.faa.gz
+curl -f -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.gene_models_main.bed.gz
+curl -f -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.cds.fna.gz
+curl -f -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.protein.faa.gz
 
-curl -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_protein.faa.gz
-curl -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_cds.fna.gz
+curl -f -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_protein.faa.gz
+curl -f -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
-curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
+curl -f -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
+curl -f -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.gene_models_main.bed.gz
-curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.cds_primary.fna.gz
-curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.protein_primary.faa.gz
+curl -f -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.gene_models_main.bed.gz
+curl -f -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.cds_primary.fna.gz
+curl -f -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.protein_primary.faa.gz
 
-curl -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.gene_models_main.bed.gz
-curl -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.cds_primary.fna.gz
-curl -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.protein_primary.faa.gz
+curl -f -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.gene_models_main.bed.gz
+curl -f -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.cds_primary.fna.gz
+curl -f -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.protein_primary.faa.gz
 
-curl -O $url_base/Vigna/GENUS/pangenes/Vigna.pan2.MQQM/Vigna.pan2.MQQM.pctl25_named_protein.faa.gz
-curl -O $url_base/Vigna/GENUS/pangenes/Vigna.pan2.MQQM/Vigna.pan2.MQQM.pctl25_named_cds.fna.gz
+curl -f -O $url_base/Vigna/GENUS/pangenes/Vigna.pan2.MQQM/Vigna.pan2.MQQM.pctl25_named_protein.faa.gz
+curl -f -O $url_base/Vigna/GENUS/pangenes/Vigna.pan2.MQQM/Vigna.pan2.MQQM.pctl25_named_cds.fna.gz
 
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.gene_models_main.bed.gz
 
 # Rename CDS-based bed files to protein
 for file in *.gene_models_main.bed.gz; do

--- a/get_data/get_family_18_3.sh
+++ b/get_data/get_family_18_3.sh
@@ -17,7 +17,7 @@ base_dir=$PWD
 cd $base_dir/data/
 
 curl -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.cds_primary.fna.gz
-curl -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.cds.bed.gz
+curl -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.gene_models_main.bed.gz
 curl -O $url_base/Aeschynomene/evenia/annotations/CIAT22838.gnm1.ann1.ZM3R/aesev.CIAT22838.gnm1.ann1.ZM3R.protein_primary.faa.gz
 
 curl -O $url_base/Arachis/GENUS/pangenes/Arachis.pan2.5P1K/Arachis.pan2.5P1K.pctl40_named_protein.faa.gz
@@ -28,24 +28,24 @@ curl -O $url_base/Cicer/GENUS/pangenes/Cicer.pan2.CMWZ/Cicer.pan2.CMWZ.pctl25_na
 
 curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
 curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds.bed.gz
+curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.cds.fna.gz
 curl -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.protein.faa.gz
-curl -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.cds.bed.gz
+curl -O $url_base/annex/Dalbergia/odorifera/annotations/SKLTGB.gnm1.ann1.R67B/dalod.SKLTGB.gnm1.ann1.R67B.gene_models_main.bed.gz
 
 curl -O $url_base/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.pctl25_named_protein.faa.gz
 curl -O $url_base/Glycine/GENUS/pangenes/Glycine.pan4.RK4P/Glycine.pan4.RK4P.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.cds.bed.gz
+curl -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.gene_models_main.bed.gz
 curl -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.cds.fna.gz
 curl -O $url_base/Lens/culinaris/annotations/CDC_Redberry.gnm2.ann1.5FB4/lencu.CDC_Redberry.gnm2.ann1.5FB4.protein.faa.gz
 
-curl -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.cds.bed.gz
+curl -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.gene_models_main.bed.gz
 curl -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.cds_primary.fna.gz
 curl -O $url_base/Lotus/japonicus/annotations/MG20.gnm3.ann1.WF9B/lotja.MG20.gnm3.ann1.WF9B.protein_primary.faa.gz
 
-curl -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.cds.bed.gz
+curl -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.gene_models_main.bed.gz
 curl -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.cds.fna.gz
 curl -O $url_base/Lupinus/albus/annotations/Amiga.gnm1.ann1.3GKS/lupal.Amiga.gnm1.ann1.3GKS.protein.faa.gz
 
@@ -55,11 +55,11 @@ curl -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.
 curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
 curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.cds.bed.gz
+curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.gene_models_main.bed.gz
 curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.cds_primary.fna.gz
 curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.protein_primary.faa.gz
 
-curl -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.cds.bed.gz
+curl -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.gene_models_main.bed.gz
 curl -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.cds_primary.fna.gz
 curl -O $url_base/Vicia/faba/annotations/Hedin2.gnm1.ann1.PTNK/vicfa.Hedin2.gnm1.ann1.PTNK.protein_primary.faa.gz
 
@@ -68,19 +68,19 @@ curl -O $url_base/Vigna/GENUS/pangenes/Vigna.pan2.MQQM/Vigna.pan2.MQQM.pctl25_na
 
 curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
 curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds.bed.gz
+curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
 curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds.bed.gz
+curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
 curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds.bed.gz
+curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
 curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds.bed.gz
+curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
 curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
@@ -92,15 +92,13 @@ curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CA
 
 curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
 curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds.bed.gz
+curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.gene_models_main.bed.gz
 
 # Rename CDS-based bed files to protein
-for file in *.cds.bed.gz; do
-  base=`basename $file .cds.bed.gz`
+for file in *.gene_models_main.bed.gz; do
+  base=`basename $file .gene_models_main.bed.gz`
   mv $file $base.protein.bed.gz
 done
-
-mv vicfa.Hedin2.gnm1.ann1.PTNK.cds.bed.gz vicfa.Hedin2.gnm1.ann1.PTNK.protein.bed.gz
 
 # From the pan-gene protein files, derive bed files
 for file in *.pctl25_named_protein.faa.gz; do 
@@ -127,4 +125,6 @@ done
 # Re-compress the files
 for file in *bed; do gzip $file &
 done
+
+wait
 

--- a/get_data/get_family_7_3.sh
+++ b/get_data/get_family_7_3.sh
@@ -18,46 +18,46 @@ url_base="https://data.legumeinfo.org"
 base_dir=$PWD
 cd $base_dir/data_fam/
 
-curl -O $url_base/Glycine/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.cds_primary.fna.gz
-curl -O $url_base/Glycine/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.gene_models_main.gff3.gz
-curl -O $url_base/Glycine/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.protein_primary.faa.gz
+curl -f -O $url_base/Glycine/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.cds_primary.fna.gz
+curl -f -O $url_base/Glycine/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.gene_models_main.gff3.gz
+curl -f -O $url_base/Glycine/max/annotations/Wm82.gnm4.ann1.T8TQ/glyma.Wm82.gnm4.ann1.T8TQ.protein_primary.faa.gz
 
-curl -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds_primary.fna.gz
-curl -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.gff3.gz
-curl -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.protein_primary.faa.gz
+curl -f -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds_primary.fna.gz
+curl -f -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.gff3.gz
+curl -f -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.protein_primary.faa.gz
 
-curl -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.cds_primary.fna.gz
-curl -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.gff3.gz
-curl -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.protein_primary.faa.gz
+curl -f -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.cds_primary.fna.gz
+curl -f -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.gff3.gz
+curl -f -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.protein_primary.faa.gz
 
-curl -O $url_base/Vigna/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.cds_primary.fna.gz
-curl -O $url_base/Vigna/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.gene_models_main.gff3.gz
-curl -O $url_base/Vigna/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.protein_primary.faa.gz
+curl -f -O $url_base/Vigna/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.cds_primary.fna.gz
+curl -f -O $url_base/Vigna/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.gene_models_main.gff3.gz
+curl -f -O $url_base/Vigna/unguiculata/annotations/IT97K-499-35.gnm1.ann2.FD7K/vigun.IT97K-499-35.gnm1.ann2.FD7K.protein_primary.faa.gz
 
-curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.cds_primary.fna.gz
-curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.gene_models_main.gff3.gz
-curl -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.protein_primary.faa.gz
+curl -f -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.cds_primary.fna.gz
+curl -f -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.gene_models_main.gff3.gz
+curl -f -O $url_base/Pisum/sativum/annotations/Cameor.gnm1.ann1.7SZR/pissa.Cameor.gnm1.ann1.7SZR.protein_primary.faa.gz
 
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.gff3.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
 
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.gff3.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
 
 
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.gff3.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
 
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.gff3.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
 
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.gff3.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
 
 # Convert from gff3 to bed7 
 for file in *gff3.gz; do 

--- a/get_data/get_family_sup.sh
+++ b/get_data/get_family_sup.sh
@@ -22,25 +22,31 @@ curl -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.
 curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
 curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
 
+curl -O $url_base/Cajanus/cajan/annotations/ICPL87119.gnm2.ann1.L3ZH/cajca.ICPL87119.gnm2.ann1.L3ZH.cds_primary.fna.gz
+curl -O $url_base/Cajanus/cajan/annotations/ICPL87119.gnm2.ann1.L3ZH/cajca.ICPL87119.gnm2.ann1.L3ZH.protein_primary.faa.gz
+
 curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
 curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds.bed.gz
+curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.bed.gz
+
+curl -O $url_base/Trifolium/pratense/annotations/MilvusB.gnm2.ann1.DFgp/tripr.MilvusB.gnm2.ann1.DFgp.cds_primary.fna.gz
+curl -O $url_base/Trifolium/pratense/annotations/MilvusB.gnm2.ann1.DFgp/tripr.MilvusB.gnm2.ann1.DFgp.protein_primary.faa.gz
 
 curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
 curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds.bed.gz
+curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
 curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds.bed.gz
+curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
 curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds.bed.gz
+curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
 curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds.bed.gz
+curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.bed.gz
 
 curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
 curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz

--- a/get_data/get_family_sup.sh
+++ b/get_data/get_family_sup.sh
@@ -16,52 +16,52 @@ url_base="https://data.legumeinfo.org"
 base_dir=$PWD
 cd $base_dir/data_sup/
 
-curl -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_protein.faa.gz
-curl -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_cds.fna.gz
+curl -f -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_protein.faa.gz
+curl -f -O $url_base/Medicago/GENUS/pangenes/Medicago.pan2.451K/Medicago.pan2.451K.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
-curl -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
+curl -f -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_protein.faa.gz
+curl -f -O $url_base/Phaseolus/GENUS/pangenes/Phaseolus.pan2.G5HV/Phaseolus.pan2.G5HV.pctl25_named_cds.fna.gz
 
-curl -O $url_base/Cajanus/cajan/annotations/ICPL87119.gnm2.ann1.L3ZH/cajca.ICPL87119.gnm2.ann1.L3ZH.cds_primary.fna.gz
-curl -O $url_base/Cajanus/cajan/annotations/ICPL87119.gnm2.ann1.L3ZH/cajca.ICPL87119.gnm2.ann1.L3ZH.protein_primary.faa.gz
+curl -f -O $url_base/Cajanus/cajan/annotations/ICPL87119.gnm2.ann1.L3ZH/cajca.ICPL87119.gnm2.ann1.L3ZH.cds_primary.fna.gz
+curl -f -O $url_base/Cajanus/cajan/annotations/ICPL87119.gnm2.ann1.L3ZH/cajca.ICPL87119.gnm2.ann1.L3ZH.protein_primary.faa.gz
 
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.bed.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.bed.gz
 
-curl -O $url_base/Trifolium/pratense/annotations/MilvusB.gnm2.ann1.DFgp/tripr.MilvusB.gnm2.ann1.DFgp.cds_primary.fna.gz
-curl -O $url_base/Trifolium/pratense/annotations/MilvusB.gnm2.ann1.DFgp/tripr.MilvusB.gnm2.ann1.DFgp.protein_primary.faa.gz
+curl -f -O $url_base/Trifolium/pratense/annotations/MilvusB.gnm2.ann1.DFgp/tripr.MilvusB.gnm2.ann1.DFgp.cds_primary.fna.gz
+curl -f -O $url_base/Trifolium/pratense/annotations/MilvusB.gnm2.ann1.DFgp/tripr.MilvusB.gnm2.ann1.DFgp.protein_primary.faa.gz
 
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
-curl -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.protein_primary.faa.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.cds_primary.fna.gz
+curl -f -O $url_base/annex/Prunus/persica/annotations/Lovell.gnm2.ann1.S2ZZ/prupe.Lovell.gnm2.ann1.S2ZZ.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.bed.gz
 
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.bed.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.bed.gz
 
 
-curl -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.cds_primary.fna.gz
-curl -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.protein_primary.faa.gz
+curl -f -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.cds_primary.fna.gz
+curl -f -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.protein_primary.faa.gz
 
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
 
 
 cd $base_dir

--- a/get_data/get_family_sup_ur.sh
+++ b/get_data/get_family_sup_ur.sh
@@ -16,38 +16,38 @@ url_base="https://data.legumeinfo.org"
 base_dir=$PWD
 cd $base_dir/data_sup/
 
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
-curl -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.protein_primary.faa.gz
-curl -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.protein_primary.faa.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
-curl -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.protein_primary.faa.gz
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.protein_primary.faa.gz
+curl -f -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.protein_primary.faa.gz
+curl -f -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.protein_primary.faa.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.protein_primary.faa.gz
+curl -f -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.protein_primary.faa.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.protein_primary.faa.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.protein_primary.faa.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.protein.faa.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.protein.faa.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.protein_primary.faa.gz
 
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
-curl -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds_primary.fna.gz
-curl -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.cds_primary.fna.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
-curl -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.cds_primary.fna.gz
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.cds_primary.fna.gz
+curl -f -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.cds_primary.fna.gz
+curl -f -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.cds_primary.fna.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.cds_primary.fna.gz
+curl -f -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.cds_primary.fna.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.cds_primary.fna.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.cds_primary.fna.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.cds.fna.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.cds.fna.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.cds_primary.fna.gz
 
-curl -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.gff3.gz
-curl -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.gff3.gz
-curl -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.gff3.gz
-curl -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.gff3.gz
-curl -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.gene_models_main.gff3.gz
-curl -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.gene_models_main.gff3.gz
-curl -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.gff3.gz
-curl -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.gff3.gz
-curl -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.gff3.gz
-curl -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.gff3.gz
+curl -f -O $url_base/Cercis/canadensis/annotations/ISC453364.gnm3.ann1.3N1M/cerca.ISC453364.gnm3.ann1.3N1M.gene_models_main.gff3.gz
+curl -f -O $url_base/Medicago/truncatula/annotations/A17_HM341.gnm4.ann2.G3ZY/medtr.A17_HM341.gnm4.ann2.G3ZY.gene_models_main.gff3.gz
+curl -f -O $url_base/Phaseolus/vulgaris/annotations/G19833.gnm2.ann1.PB8d/phavu.G19833.gnm2.ann1.PB8d.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Arabidopsis/thaliana/annotations/Col0.gnm9.ann11.KH24/arath.Col0.gnm9.ann11.KH24.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Bauhinia/variegata/annotations/BV-YZ2020.gnm2.ann1.RJ1G/bauva.BV-YZ2020.gnm2.ann1.RJ1G.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Chamaecrista/fasciculata/annotations/ISC494698.gnm1.ann1.G7XW/chafa.ISC494698.gnm1.ann1.G7XW.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Quillaja/saponaria/annotations/S10.gnm1.ann1.RQ4J/quisa.S10.gnm1.ann1.RQ4J.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Senna/tora/annotations/Myeongyun.gnm1.ann1.5WXB/sento.Myeongyun.gnm1.ann1.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Sindora/glabra/annotations/CAF01.gnm1.ann1.WFKC/singl.CAF01.gnm1.ann1.WFKC.gene_models_main.gff3.gz
+curl -f -O $url_base/annex/Vitis/vinifera/annotations/PN40024.gnm2.ann1.V31M/vitvi.PN40024.gnm2.ann1.V31M.gene_models_main.gff3.gz
 
 cd $base_dir
 


### PR DESCRIPTION
Updates to improve consistency between scripts that fetch data (get_data/*) and configuration files that specify which files are used (config/*).

Note that the get_data/ scripts aren't necessarily idempotent, nor can multiple scripts be run in an arbitrary order from the same working directory, but each individual get_data/ scripts should work when run from distinct working directories.