### PR TITLE
Add Medicago3_8_0_15 to GA workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     inputs:
       pandagma-conf:
         # Glycine5_21_29_6 times out
-        # Medicago3_8_0_15 isn't ready
         default: '["Arachis3_5_2_0", "Cicer3_4_2_0", "Glycine_7_3_2", "Medicago3_8_0_15", "Vigna4_7_1_4"]'
         description: Run pandagma pan for each config/NAME.conf file in the (JSON) array
         required: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,7 +6,7 @@ on:
       pandagma-conf:
         # Glycine5_21_29_6 times out
         # Medicago3_8_0_15 isn't ready
-        default: '["Arachis3_5_2_0", "Cicer3_4_2_0", "Glycine_7_3_2", "Vigna4_7_1_4"]'
+        default: '["Arachis3_5_2_0", "Cicer3_4_2_0", "Glycine_7_3_2", "Medicago3_8_0_15", "Vigna4_7_1_4"]'
         description: Run pandagma pan for each config/NAME.conf file in the (JSON) array
         required: true
       ssh_enabled:


### PR DESCRIPTION
The `pandagma pan` workflow for Medicago3_8_0_15 now passes, and can be added to the default list in the GA workflow:

https://github.com/legumeinfo/pandagma/actions/runs/7784699541